### PR TITLE
Rename Debug.h -> Debug_Espfc.h for windows build

### DIFF
--- a/lib/Espfc/src/Debug_Espfc.h
+++ b/lib/Espfc/src/Debug_Espfc.h
@@ -1,8 +1,8 @@
 #ifndef _ESPFC_DEBUG_H_
 #define _ESPFC_DEBUG_H_
 
-#include <EspGpio.h>
 #include <Arduino.h>
+#include <EspGpio.h>
 
 namespace Espfc
 {

--- a/lib/Espfc/src/Device/BaroBMP085.h
+++ b/lib/Espfc/src/Device/BaroBMP085.h
@@ -3,7 +3,7 @@
 
 #include "BusDevice.h"
 #include "BaroDevice.h"
-#include "Debug.h"
+#include "Debug_Espfc.h"
 
 #define BMP085_DEFAULT_ADDRESS 0x77
 

--- a/lib/Espfc/src/Device/BaroBMP280.h
+++ b/lib/Espfc/src/Device/BaroBMP280.h
@@ -3,7 +3,7 @@
 
 #include "BusDevice.h"
 #include "BaroDevice.h"
-#include "Debug.h"
+#include "Debug_Espfc.h"
 
 #define BMP280_DEFAULT_ADDRESS        0x77
 #define BMP280_WHOAMI_ID              0x58

--- a/lib/Espfc/src/Device/BusSPI.h
+++ b/lib/Espfc/src/Device/BusSPI.h
@@ -2,7 +2,7 @@
 #define _ESPFC_DEVICE_BUSSPI_H_
 
 #include "BusDevice.h"
-#include "Debug.h"
+#include "Debug_Espfc.h"
 #include <SPI.h>
 
 namespace Espfc {

--- a/lib/Espfc/src/Device/GyroMPU6050.h
+++ b/lib/Espfc/src/Device/GyroMPU6050.h
@@ -4,7 +4,7 @@
 #include "BusDevice.h"
 #include "GyroDevice.h"
 #include "helper_3dmath.h"
-#include "Debug.h"
+#include "Debug_Espfc.h"
 
 #define MPU6050_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board
 #define MPU6050_ADDRESS_AD0_HIGH    0x69 // address pin high (VCC)

--- a/lib/Espfc/src/Device/GyroMPU9250.h
+++ b/lib/Espfc/src/Device/GyroMPU9250.h
@@ -4,7 +4,7 @@
 #include "BusDevice.h"
 #include "GyroMPU6050.h"
 #include "helper_3dmath.h"
-#include "Debug.h"
+#include "Debug_Espfc.h"
 
 #define MPU9250_USER_CTRL         0x6A
 #define MPU9250_I2C_MST_EN        0x20

--- a/lib/Espfc/src/Logger.h
+++ b/lib/Espfc/src/Logger.h
@@ -2,7 +2,7 @@
 #define _ESPFC_LOGGER_H_
 
 #include <Arduino.h>
-#include "Debug.h"
+#include "Debug_Espfc.h"
 
 #if defined(ESP32)
 #include "SPIFFS.h"

--- a/lib/Espfc/src/Model.h
+++ b/lib/Espfc/src/Model.h
@@ -8,7 +8,7 @@
 #include <EscDriver.h>
 #include <Hal.h>
 
-#include "Debug.h"
+#include "Debug_Espfc.h"
 #include "ModelConfig.h"
 #include "ModelState.h"
 #include "Storage.h"


### PR DESCRIPTION
Project didn't build on Windows platform because Debug.h clashed with debug.h from the esp8299 library. 
Giving the project Debug.h file a custom name fixed this issue. 

Fixes #25 