### PR TITLE
add gyro bmi160 and fix gyro i2c address

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ After flashing you need to configure few things first:
 | AK8963/I2C      | -       |   Yes |    Yes |
 | ICM20602/I2C    | ?       |     ? |      ? |
 | ICM20602/SPI    | -       |   Yes |    Yes |
+| BMI160/I2C      | ?       |   Yes |      ? |
+| BMI160/SPI      | -       |   Yes |    Yes |
 
 ? - not tested, but should work
 

--- a/lib/Espfc/src/Device/BaroBMP280.h
+++ b/lib/Espfc/src/Device/BaroBMP280.h
@@ -5,7 +5,8 @@
 #include "BaroDevice.h"
 #include "Debug_Espfc.h"
 
-#define BMP280_DEFAULT_ADDRESS        0x77
+#define BMP280_ADDRESS_FIRST          0x76
+#define BMP280_ADDRESS_SECOND         0x77
 #define BMP280_WHOAMI_ID              0x58
 
 #define BMP280_WHOAMI_REG             0xD0
@@ -60,7 +61,7 @@ class BaroBMP280: public BaroDevice
 
     int begin(BusDevice * bus) override
     {
-      return begin(bus, BMP280_DEFAULT_ADDRESS);
+      return begin(bus, BMP280_ADDRESS_FIRST) ? 1 : begin(bus, BMP280_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/BusDevice.h
+++ b/lib/Espfc/src/Device/BusDevice.h
@@ -72,6 +72,19 @@ class BusDevice
       return count;
     }
 
+    int8_t readBitsBMI160(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t *data)
+    {
+      uint8_t count, b;
+      if ((count = readByte(devAddr, regAddr, &b)) != 0)
+      {
+        uint8_t mask = (1 << length) - 1;
+        b >>= bitStart;
+        b &= mask;
+        *data = b;
+      }
+      return count;
+    }
+
     bool writeBit(uint8_t devAddr, uint8_t regAddr, uint8_t bitNum, uint8_t data)
     {
       uint8_t b;
@@ -87,6 +100,22 @@ class BusDevice
       {
         uint8_t mask = ((1 << length) - 1) << (bitStart - length + 1);
         data <<= (bitStart - length + 1); // shift data into correct position
+        data &= mask; // zero all non-important bits in data
+        b &= ~(mask); // zero all important bits in existing byte
+        b |= data; // combine data with existing byte
+        return writeByte(devAddr, regAddr, b);
+      } else {
+        return false;
+      }
+    }
+
+    bool writeBitsBMI160(uint8_t devAddr, uint8_t regAddr, uint8_t bitStart, uint8_t length, uint8_t data)
+    {
+      uint8_t b = 0;
+      if (readByte(devAddr, regAddr, &b) != 0)
+      {
+        uint8_t mask = ((1 << length) - 1) << bitStart;
+        data <<= bitStart; // shift data into correct position
         data &= mask; // zero all non-important bits in data
         b &= ~(mask); // zero all important bits in existing byte
         b |= data; // combine data with existing byte

--- a/lib/Espfc/src/Device/GyroBMI160.h
+++ b/lib/Espfc/src/Device/GyroBMI160.h
@@ -1,0 +1,175 @@
+#ifndef _ESPFC_DEVICE_GYRO_BMI160_H_
+#define _ESPFC_DEVICE_GYRO_BMI160_H_
+
+#include "BusDevice.h"
+#include "GyroDevice.h"
+#include "helper_3dmath.h"
+#include "Debug_Espfc.h"
+
+#define BMI160_ADDRESS_FIRST      0x69
+#define BMI160_ADDRESS_SECOND     0x68
+#define BMI160_RA_CHIP_ID           0x00
+#define BMI160_CHIP_ID_DEFAULT_VALUE 0xD1
+
+#define BMI160_RA_GYRO_X_L          0x0C
+#define BMI160_RA_GYRO_X_H          0x0D
+#define BMI160_RA_GYRO_Y_L          0x0E
+#define BMI160_RA_GYRO_Y_H          0x0F
+#define BMI160_RA_GYRO_Z_L          0x10
+#define BMI160_RA_GYRO_Z_H          0x11
+#define BMI160_RA_ACCEL_X_L         0x12
+#define BMI160_RA_ACCEL_X_H         0x13
+#define BMI160_RA_ACCEL_Y_L         0x14
+#define BMI160_RA_ACCEL_Y_H         0x15
+#define BMI160_RA_ACCEL_Z_L         0x16
+#define BMI160_RA_ACCEL_Z_H         0x17
+
+#define BMI160_RA_ACCEL_CONF        0X40
+#define BMI160_RA_ACCEL_RANGE       0X41
+
+#define BMI160_RA_GYRO_CONF         0X42
+#define BMI160_RA_GYRO_RANGE        0X43
+
+#define BMI160_CMD_START_FOC        0x03
+#define BMI160_CMD_ACC_MODE_NORMAL  0x11
+#define BMI160_CMD_GYR_MODE_NORMAL  0x15
+#define BMI160_CMD_FIFO_FLUSH       0xB0
+#define BMI160_CMD_INT_RESET        0xB1
+#define BMI160_CMD_STEP_CNT_CLR     0xB2
+#define BMI160_CMD_SOFT_RESET       0xB6
+
+#define BMI160_RA_CMD               0x7E
+
+namespace Espfc {
+
+namespace Device {
+
+class GyroBMI160: public GyroDevice
+{
+  public:
+    int begin(BusDevice * bus) override
+    {
+      return begin(bus, BMI160_ADDRESS_FIRST) ? 1 : begin(bus, BMI160_ADDRESS_SECOND) ? 1 : 0;
+    }
+
+    int begin(BusDevice * bus, uint8_t addr) override
+    {
+      setBus(bus, addr);
+
+      if(!testConnection()) return 0;
+
+      // reset device
+      _bus->writeByte(_addr, BMI160_RA_CMD, BMI160_CMD_SOFT_RESET);
+      delay(1);
+
+      /* Issue a dummy-read to force the device into SPI comms mode */
+      uint8_t dummy = 0;
+      _bus->readByte(_addr, 0x7F, &dummy);
+      delay(1);
+
+      // Start up accelerometer
+      _bus->writeByte(_addr, BMI160_RA_CMD, BMI160_CMD_ACC_MODE_NORMAL);
+      delay(100);
+
+      // Start up gyroscope
+      _bus->writeByte(_addr, BMI160_RA_CMD, BMI160_CMD_GYR_MODE_NORMAL);
+      delay(100);
+
+      // // Set odr and ranges
+      // // Set acc_us = 0 & acc_bwp = 0b001 for high performance and OSR2 mode
+      // _bus->writeByte(_addr, BMI160_RA_ACCEL_CONF, 0x00 | 0x10 | 0x0B);
+      // delay(1);
+
+      // // Set up full scale Accel range. +-16G
+      _bus->writeByte(_addr, BMI160_RA_ACCEL_RANGE, 0x0C);
+      delay(1);
+
+      // // Set up full scale Gyro range. +-2000dps
+      _bus->writeByte(_addr, BMI160_RA_GYRO_RANGE, 0x00);
+      delay(1);
+
+      // Set Accel ODR to 400hz, BWP mode to Oversample 4, LPF of ~40.5hz
+      _bus->writeByte(_addr, BMI160_RA_ACCEL_CONF, 0x0A);
+      delay(1);
+
+      // Set Gyro ODR to 400hz, BWP mode to Oversample 4, LPF of ~34.15hz
+      _bus->writeByte(_addr, BMI160_RA_GYRO_CONF, 0x0A);
+      delay(1);
+
+      return 1;
+    }
+
+    GyroDeviceType getType() const override
+    {
+      return GYRO_BMI160;
+    }
+
+    int readGyro(VectorInt16& v) override
+    {
+      uint8_t buffer[6];
+
+      _bus->readFast(_addr, BMI160_RA_GYRO_X_L, 6, buffer);
+
+      v.x = (((int16_t)buffer[1]) << 8) | buffer[0];
+      v.y = (((int16_t)buffer[3]) << 8) | buffer[2];
+      v.z = (((int16_t)buffer[5]) << 8) | buffer[4];
+
+      return 1;
+    }
+
+    int readAccel(VectorInt16& v) override
+    {
+      uint8_t buffer[6];
+
+      _bus->readFast(_addr, BMI160_RA_ACCEL_X_L, 6, buffer);
+
+      v.x = (((int16_t)buffer[1]) << 8) | buffer[0];
+      v.y = (((int16_t)buffer[3]) << 8) | buffer[2];
+      v.z = (((int16_t)buffer[5]) << 8) | buffer[4];
+
+      return 1;
+    }
+
+    void setDLPFMode(uint8_t mode) override
+    {
+    }
+
+    int getRate() const override
+    {
+      return 8000;
+    }
+
+    void setRate(int rate) override
+    {
+    }
+
+    void setFullScaleGyroRange(uint8_t range) override
+    {
+    }
+
+    void setFullScaleAccelRange(uint8_t range) override
+    {
+    }
+
+    bool testConnection() override
+    {
+      uint8_t whoami = 0;
+      _bus->readByte(_addr, BMI160_RA_CHIP_ID, &whoami);
+      //D("bmi160:whoami", _addr, whoami);
+      return whoami == BMI160_CHIP_ID_DEFAULT_VALUE;
+    }
+
+    void setSleepEnabled(bool enabled)
+    {
+    }
+
+    void setClockSource(uint8_t source)
+    {
+    }
+};
+
+}
+
+}
+
+#endif

--- a/lib/Espfc/src/Device/GyroDevice.h
+++ b/lib/Espfc/src/Device/GyroDevice.h
@@ -16,6 +16,7 @@ enum GyroDeviceType {
   GYRO_MPU9250 = 5,
   GYRO_LSM6DSO = 6,
   GYRO_ICM20602 = 7,
+  GYRO_BMI160 = 8,
   GYRO_MAX
 };
 
@@ -44,7 +45,7 @@ class GyroDevice: public BusAwareDevice
 
     static const char ** getNames()
     {
-      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("MPU6000"), PSTR("MPU6050"), PSTR("MPU6500"), PSTR("MPU9250"), PSTR("LSM6DSO"), PSTR("ICM20602"), NULL };
+      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("MPU6000"), PSTR("MPU6050"), PSTR("MPU6500"), PSTR("MPU9250"), PSTR("LSM6DSO"), PSTR("ICM20602"),PSTR("BMI160"), NULL };
       return devChoices;
     }
 

--- a/lib/Espfc/src/Device/GyroICM20602.h
+++ b/lib/Espfc/src/Device/GyroICM20602.h
@@ -6,9 +6,8 @@
 #include "helper_3dmath.h"
 #include "Debug_Espfc.h"
 
-#define ICM20602_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board
-#define ICM20602_ADDRESS_AD0_HIGH    0x69 // address pin high (VCC)
-#define ICM20602_DEFAULT_ADDRESS     ICM20602_ADDRESS_AD0_LOW
+#define ICM20602_ADDRESS_FIRST       0x68 // address pin low (GND), default for InvenSense evaluation board
+#define ICM20602_ADDRESS_SECOND      0x69 // address pin high (VCC)
 
 #define ICM20602_RA_SMPLRT_DIV       0x19
 #define ICM20602_RA_CONFIG           0x1A
@@ -87,7 +86,7 @@ class GyroICM20602: public GyroDevice
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, ICM20602_DEFAULT_ADDRESS);
+      return begin(bus, ICM20602_ADDRESS_FIRST) ? 1 : begin(bus, ICM20602_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/GyroLSM6DSO.h
+++ b/lib/Espfc/src/Device/GyroLSM6DSO.h
@@ -7,7 +7,8 @@
 #include "Debug_Espfc.h"
 
 // https://github.com/arduino-libraries/Arduino_LSM6DSOX/blob/master/src/LSM6DSOX.cpp
-#define LSM6DSOX_DEFAULT_ADDRESS    0x6A
+#define LSM6DSOX_ADDRESS_FIRST     0x6A
+#define LSM6DSOX_ADDRESS_SECOND    0x6b
 
 // registers
 #define LSM6DSO_REG_WHO_AM_I       0x0F
@@ -69,7 +70,7 @@ class GyroLSM6DSO: public GyroDevice
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, LSM6DSOX_DEFAULT_ADDRESS);
+      return begin(bus, LSM6DSOX_ADDRESS_FIRST) ? 1 : begin(bus, LSM6DSOX_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/GyroMPU6050.h
+++ b/lib/Espfc/src/Device/GyroMPU6050.h
@@ -6,9 +6,8 @@
 #include "helper_3dmath.h"
 #include "Debug_Espfc.h"
 
-#define MPU6050_ADDRESS_AD0_LOW     0x68 // address pin low (GND), default for InvenSense evaluation board
-#define MPU6050_ADDRESS_AD0_HIGH    0x69 // address pin high (VCC)
-#define MPU6050_DEFAULT_ADDRESS     MPU6050_ADDRESS_AD0_LOW
+#define MPU6050_ADDRESS_FIRST       0x68 // address pin low (GND), default for InvenSense evaluation board
+#define MPU6050_ADDRESS_SECOND      0x69 // address pin high (VCC)
 
 #define MPU6050_RA_SMPLRT_DIV       0x19
 #define MPU6050_RA_CONFIG           0x1A
@@ -87,7 +86,7 @@ class GyroMPU6050: public GyroDevice
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, MPU6050_DEFAULT_ADDRESS);
+      return begin(bus, MPU6050_ADDRESS_FIRST) ? 1 : begin(bus, MPU6050_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/GyroMPU6500.h
+++ b/lib/Espfc/src/Device/GyroMPU6500.h
@@ -27,7 +27,7 @@ class GyroMPU6500: public GyroMPU6050
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, MPU6050_DEFAULT_ADDRESS);
+      return begin(bus, MPU6050_ADDRESS_FIRST) ? 1 : begin(bus, MPU6050_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/GyroMPU6500.h
+++ b/lib/Espfc/src/Device/GyroMPU6500.h
@@ -17,6 +17,7 @@
 #define MPU6500_ACCEL_CONF2       0x1D
 
 #define MPU6500_WHOAMI_DEFAULT_VALUE 0x70
+#define MPU6555_WHOAMI_DEFAULT_VALUE 0x75
 
 namespace Espfc {
 
@@ -91,7 +92,7 @@ class GyroMPU6500: public GyroMPU6050
       uint8_t whoami = 0;
       _bus->readByte(_addr, MPU6050_RA_WHO_AM_I, &whoami);
       //D("MPU6500:whoami", _addr, whoami);
-      return whoami == MPU6500_WHOAMI_DEFAULT_VALUE;
+      return whoami == MPU6500_WHOAMI_DEFAULT_VALUE || whoami == MPU6555_WHOAMI_DEFAULT_VALUE;
     }
 };
 

--- a/lib/Espfc/src/Device/GyroMPU9250.h
+++ b/lib/Espfc/src/Device/GyroMPU9250.h
@@ -89,7 +89,7 @@ class GyroMPU9250: public GyroMPU6050
       uint8_t whoami = 0;
       _bus->readByte(_addr, MPU6050_RA_WHO_AM_I, &whoami);
       //D("mpu9250:whoami", _addr, whoami);
-      return whoami == 0x71 || whoami == 0x73 || whoami == 0x75;
+      return whoami == 0x71 || whoami == 0x73;
     }
 };
 

--- a/lib/Espfc/src/Device/GyroMPU9250.h
+++ b/lib/Espfc/src/Device/GyroMPU9250.h
@@ -89,7 +89,7 @@ class GyroMPU9250: public GyroMPU6050
       uint8_t whoami = 0;
       _bus->readByte(_addr, MPU6050_RA_WHO_AM_I, &whoami);
       //D("mpu9250:whoami", _addr, whoami);
-      return whoami == 0x71 || whoami == 0x73;
+      return whoami == 0x71 || whoami == 0x73 || whoami == 0x75;
     }
 };
 

--- a/lib/Espfc/src/Device/GyroMPU9250.h
+++ b/lib/Espfc/src/Device/GyroMPU9250.h
@@ -25,7 +25,7 @@ class GyroMPU9250: public GyroMPU6050
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, MPU6050_DEFAULT_ADDRESS);
+      return begin(bus, MPU6050_ADDRESS_FIRST) ? 1 : begin(bus, MPU6050_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override

--- a/lib/Espfc/src/Device/MagAK8963.h
+++ b/lib/Espfc/src/Device/MagAK8963.h
@@ -4,8 +4,8 @@
 #include "MagDevice.h"
 #include "BusDevice.h"
 
-#define MPU9250_ADDRESS           0x68
-#define MPU9250_DEFAULT_ADDRESS   MPU9250_ADDRESS
+#define MPU9250_ADDRESS_FIRST     0x68
+#define MPU9250_ADDRESS_SECOND    0x68
 #define MPU9250_I2C_SLV0_ADDR     0x25
 #define MPU9250_I2C_SLV0_REG      0x26
 #define MPU9250_I2C_SLV0_DO       0x63
@@ -37,14 +37,14 @@ class MagAK8963: public MagDevice
   public:
     int begin(BusDevice * bus) override
     {
-      return begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_DEFAULT_ADDRESS);
+      return begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_ADDRESS_FIRST) ? 1 : begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_ADDRESS_SECOND) ? 1 : 0;
     }
 
     int begin(BusDevice * bus, uint8_t addr) override
     {
       if(bus->getType() == BUS_I2C)
       {
-        return begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_DEFAULT_ADDRESS);
+        return begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_ADDRESS_FIRST) ? 1 : begin(bus, AK8963_DEFAULT_ADDRESS, MPU9250_ADDRESS_SECOND) ? 1 : 0;
       }
       else
       {

--- a/lib/Espfc/src/Hardware.h
+++ b/lib/Espfc/src/Hardware.h
@@ -17,6 +17,7 @@
 #include "Device/GyroMPU9250.h"
 #include "Device/GyroLSM6DSO.h"
 #include "Device/GyroICM20602.h"
+#include "Device/GyroBMI160.h"
 #include "Device/MagHMC5338L.h"
 #include "Device/MagAK8963.h"
 #include "Device/BaroDevice.h"
@@ -38,6 +39,7 @@ namespace {
   static Espfc::Device::GyroMPU9250 mpu9250;
   static Espfc::Device::GyroLSM6DSO lsm6dso;
   static Espfc::Device::GyroICM20602 icm20602;
+  static Espfc::Device::GyroBMI160 bmi160;
   static Espfc::Device::MagHMC5338L hmc5883l;
   static Espfc::Device::MagAK8963 ak8963;
   static Espfc::Device::BaroBMP085 bmp085;
@@ -92,6 +94,7 @@ class Hardware
         if(!detectedGyro && detectDevice(mpu9250, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu9250;
         if(!detectedGyro && detectDevice(mpu6500, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu6500;
         if(!detectedGyro && detectDevice(icm20602, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &icm20602;
+        if(!detectedGyro && detectDevice(bmi160, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &bmi160;
         if(!detectedGyro && detectDevice(lsm6dso, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &lsm6dso;
       }
 #endif
@@ -101,6 +104,7 @@ class Hardware
         if(!detectedGyro && detectDevice(mpu9250, i2cBus)) detectedGyro = &mpu9250;
         if(!detectedGyro && detectDevice(mpu6500, i2cBus)) detectedGyro = &mpu6500;
         if(!detectedGyro && detectDevice(icm20602, i2cBus)) detectedGyro = &icm20602;
+        if(!detectedGyro && detectDevice(bmi160, i2cBus)) detectedGyro = &bmi160;
         if(!detectedGyro && detectDevice(mpu6050, i2cBus)) detectedGyro = &mpu6050;
         if(!detectedGyro && detectDevice(lsm6dso, i2cBus)) detectedGyro = &lsm6dso;
       }

--- a/merge_firmware.py
+++ b/merge_firmware.py
@@ -1,0 +1,43 @@
+Import("env")
+
+APP_BIN = "$BUILD_DIR/${PROGNAME}.bin"
+MERGED_BIN = "$BUILD_DIR/${PROGNAME}_esp32_0x00.bin"
+BOARD_CONFIG = env.BoardConfig()
+
+
+def merge_bin(source, target, env):
+    # The list contains all extra images (bootloader, partitions, eboot) and
+    # the final application binary
+    flash_images = env.Flatten(env.get("FLASH_EXTRA_IMAGES", [])) + ["$ESP32_APP_OFFSET", APP_BIN]
+
+    # Run esptool to merge images into a single binary
+    env.Execute(
+        " ".join(
+            [
+                "$PYTHONEXE",
+                "$OBJCOPY",
+                "--chip",
+                BOARD_CONFIG.get("build.mcu", "esp32"),
+                "merge_bin",
+                "--flash_size",
+                BOARD_CONFIG.get("upload.flash_size", "4MB"),
+                "-o",
+                MERGED_BIN,
+            ]
+            + flash_images
+        )
+    )
+
+# Add a post action that runs esptoolpy to merge available flash images
+env.AddPostAction(APP_BIN , merge_bin)
+
+# Patch the upload command to flash the merged binary at address 0x0
+env.Replace(
+    UPLOADERFLAGS=[
+            f
+            for f in env.get("UPLOADERFLAGS")
+            if f not in env.Flatten(env.get("FLASH_EXTRA_IMAGES"))
+        ]
+        + ["0x0", MERGED_BIN],
+    UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS',
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -55,6 +55,7 @@ upload_speed = ${common.esp32_upload_speed}
 upload_port = ${common.esp32_upload_port}
 monitor_speed = ${common.esp32_monitor_speed}
 monitor_port = ${common.esp32_monitor_port}
+;extra_scripts = merge_firmware.py
 
 [env:esp8266]
 board = d1_mini


### PR DESCRIPTION
esp32 bmi160 on spi
![esp32_bmi160_spi](https://github.com/rtlopez/esp-fc/assets/100328812/614152c6-8b83-4a91-a1d6-dec882f7b948)

esp32 bmi160 on i2c
![esp32_bmi160_i2c](https://github.com/rtlopez/esp-fc/assets/100328812/259e0ae9-e254-4c32-aebd-de9ebf3e2f23)

rp2040 bmi160 on spi
![rp2040_bmi160_spi](https://github.com/rtlopez/esp-fc/assets/100328812/9d747b5d-6018-4a27-ad8c-8e8bf85eb238)

fix i2c address detect 0x76 and 0x77
https://github.com/rtlopez/esp-fc/issues/81