### PR TITLE
No gyro fix

### DIFF
--- a/lib/Espfc/src/Model.h
+++ b/lib/Espfc/src/Model.h
@@ -604,8 +604,8 @@ class Model
   private:
     #ifndef UNIT_TEST
     Storage _storage;
-    StorageResult _storageResult;
     #endif
+    StorageResult _storageResult;
 };
 
 }

--- a/lib/Espfc/src/Model.h
+++ b/lib/Espfc/src/Model.h
@@ -295,6 +295,11 @@ class Model
       else
       {
         state.gyroRate = Math::alignToClock(state.gyroClock, ESPFC_GYRO_I2C_RATE_MAX);
+        // first usage
+        if(_storageResult == STORAGE_ERR_BAD_MAGIC || _storageResult == STORAGE_ERR_BAD_SIZE || _storageResult == STORAGE_ERR_BAD_VERSION)
+        {
+          config.loopSync = 1;
+        }
       }
 
       int loopSyncMax = 1;

--- a/lib/Espfc/src/Msp/MspProcessor.h
+++ b/lib/Espfc/src/Msp/MspProcessor.h
@@ -217,8 +217,17 @@ class MspProcessor
           // 1.42
           r.writeU8(2);  // configuration state: configured
           // 1.43
-          r.writeU16(_model.state.gyroTimer.rate); // sample rate
-          r.writeU32(0); // configuration problems
+          r.writeU16(_model.state.gyroPresent ? _model.state.gyroTimer.rate : 0); // sample rate
+          {
+            uint32_t problems = 0;
+            if(_model.state.accelBias.x == 0 && _model.state.accelBias.y == 0 && _model.state.accelBias.z == 0) {
+              problems |= 1 << 0; // acc calibration required
+            }
+            if(_model.config.output.protocol == ESC_PROTOCOL_DISABLED) {
+              problems |= 1 << 1; // no motor protocol
+            }
+            r.writeU32(problems); // configuration problems
+          }
           // 1.44
           r.writeU8(0);  // spi dev count
           r.writeU8(0);  // i2c dev count

--- a/lib/Espfc/src/Sensor/GyroSensor.h
+++ b/lib/Espfc/src/Sensor/GyroSensor.h
@@ -149,7 +149,7 @@ class GyroSensor: public BaseSensor
 
         if(dynNotchEnabled)
         {
-          for(size_t p = 0; p < _model.config.dynamicFilter.width; p++)
+          for(size_t p = 0; p < (size_t)_model.config.dynamicFilter.width; p++)
           {
             _model.state.gyro.set(i, _model.state.gyroDynNotchFilter[i][p].update(_model.state.gyro[i]));
           }
@@ -170,6 +170,8 @@ class GyroSensor: public BaseSensor
 
     void dynNotchAnalyze()
     {
+      if(!_model.gyroActive()) return;
+
       Stats::Measure measure(_model.state.stats, COUNTER_GYRO_FFT);
 
       bool enabled = _model.isActive(FEATURE_DYNAMIC_FILTER);
@@ -239,7 +241,8 @@ class GyroSensor: public BaseSensor
                 {
                   size_t x = (p + i) % 3;
                   int harmonic = (p / 3) + 1;
-                  _model.state.gyroDynNotchFilter[x][p].reconfigure(freq * harmonic, freq * harmonic, q);
+                  int16_t f = Math::clamp((int16_t)lrintf(freq * harmonic), _model.config.dynamicFilter.min_freq, _model.config.dynamicFilter.max_freq);
+                  _model.state.gyroDynNotchFilter[x][p].reconfigure(f, f, q);
                 }
               }
             }

--- a/lib/Espfc/src/Storage.h
+++ b/lib/Espfc/src/Storage.h
@@ -1,13 +1,6 @@
 #ifndef _ESPFC_STORAGE_H_
 #define _ESPFC_STORAGE_H_
 
-#ifndef UNIT_TEST
-
-#include <Arduino.h>
-#include "ModelConfig.h"
-#include "EEPROM.h"
-#include "Logger.h"
-
 namespace Espfc {
 
 enum StorageResult
@@ -19,6 +12,17 @@ enum StorageResult
   STORAGE_ERR_BAD_VERSION,
   STORAGE_ERR_BAD_SIZE,
 };
+
+}
+
+#ifndef UNIT_TEST
+
+#include <Arduino.h>
+#include "ModelConfig.h"
+#include "EEPROM.h"
+#include "Logger.h"
+
+namespace Espfc {
 
 class Storage
 {

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,6 +39,7 @@ esp32_build_flags =
 
 [env]
 ; monitor_filters = esp8266_exception_decoder
+; monitor_filters = esp32_exception_decoder
 
 [env:esp32]
 board = lolin32


### PR DESCRIPTION
fixes problem that board reboots when no gyro is connected or detected. So configurator cannot connect to board.