### PR TITLE
added support for MPU6555

### DIFF
--- a/lib/EscDriver/src/EscDriverEsp32.h
+++ b/lib/EscDriver/src/EscDriverEsp32.h
@@ -16,7 +16,7 @@ static const int32_t DURATION_MAX = 0x7fff; // max in 15 bits
 
 // faster esc response, but unsafe (no task synchronisation)
 // set to 0 in case of issues
-#define ESPFC_RMT_BYPASS_WRITE_SYNC 1
+#define ESPFC_RMT_BYPASS_WRITE_SYNC 0
 
 #if ESPFC_RMT_BYPASS_WRITE_SYNC
 IRAM_ATTR static esp_err_t _rmt_fill_tx_items(rmt_channel_t channel, const rmt_item32_t* item, uint16_t item_num, uint16_t mem_offset)

--- a/lib/Espfc/src/Device/GyroDevice.h
+++ b/lib/Espfc/src/Device/GyroDevice.h
@@ -16,6 +16,7 @@ enum GyroDeviceType {
   GYRO_MPU9250 = 5,
   GYRO_LSM6DSO = 6,
   GYRO_ICM20602 = 7,
+  GYRO_MPU6555 = 8,
   GYRO_MAX
 };
 

--- a/lib/Espfc/src/Device/GyroMPU6555.h
+++ b/lib/Espfc/src/Device/GyroMPU6555.h
@@ -1,0 +1,102 @@
+#ifndef _ESPFC_DEVICE_GYRO_MPU6555_H_
+#define _ESPFC_DEVICE_GYRO_MPU6555_H_
+
+#include "BusDevice.h"
+#include "GyroMPU6050.h"
+#include "helper_3dmath.h"
+#include "Debug_Espfc.h"
+
+#define MPU6555_USER_CTRL         0x6A
+#define MPU6555_I2C_MST_EN        0x20
+#define MPU6555_I2C_IF_DIS        0x10
+#define MPU6555_I2C_MST_400       0x0D
+#define MPU6555_I2C_MST_500       0x09
+#define MPU6555_I2C_MST_CTRL      0x24
+#define MPU6555_I2C_MST_RESET     0x02
+
+#define MPU6555_ACCEL_CONF2       0x1D
+
+#define MPU6555_WHOAMI_DEFAULT_VALUE 0x75
+
+namespace Espfc {
+
+namespace Device {
+
+class GyroMPU6555: public GyroMPU6050
+{
+  public:
+    int begin(BusDevice * bus) override
+    {
+      return begin(bus, MPU6050_DEFAULT_ADDRESS);
+    }
+
+    int begin(BusDevice * bus, uint8_t addr) override
+    {
+      setBus(bus, addr);
+
+      if(!testConnection()) return 0;
+
+      _bus->writeByte(_addr, MPU6050_RA_PWR_MGMT_1, MPU6050_RESET);
+      delay(100);
+
+      setClockSource(MPU6050_CLOCK_PLL_XGYRO);
+
+      setSleepEnabled(false);
+      delay(100);      
+
+      // reset I2C master
+      //_bus->writeByte(_addr, MPU6555_USER_CTRL, MPU6555_I2C_MST_RESET);
+
+      // disable I2C master to reset slave registers allocation
+      _bus->writeByte(_addr, MPU6555_USER_CTRL, 0);
+      //delay(100);
+
+      // temporary force 1k sample rate for mag initiation, will be overwritten in GyroSensor
+      setDLPFMode(GYRO_DLPF_188);
+      setRate(9); // 1000 / (9+1) = 100hz
+      delay(100);
+
+      // enable I2C master mode, and disable I2C if SPI
+      if(_bus->isSPI())
+      {
+        _bus->writeByte(_addr, MPU6555_USER_CTRL, MPU6555_I2C_MST_EN | MPU6555_I2C_IF_DIS);
+      }
+      else
+      {
+        _bus->writeByte(_addr, MPU6555_USER_CTRL, MPU6555_I2C_MST_EN);
+      }
+      //delay(100);
+
+      // set the I2C bus speed to 400 kHz
+      _bus->writeByte(_addr, MPU6555_I2C_MST_CTRL, MPU6555_I2C_MST_400);
+      //delay(100);
+
+      return 1;
+    }
+
+    GyroDeviceType getType() const override
+    {
+      return GYRO_MPU6555;
+    }
+
+    void setDLPFMode(uint8_t mode) override
+    {
+      GyroMPU6050::setDLPFMode(mode);
+      _bus->writeByte(_addr, MPU6555_ACCEL_CONF2, mode);
+    }
+
+
+    bool testConnection() override
+    {
+      uint8_t whoami = 0;
+      _bus->readByte(_addr, MPU6050_RA_WHO_AM_I, &whoami);
+      //D("MPU6555:whoami", _addr, whoami);
+      return whoami == MPU6555_WHOAMI_DEFAULT_VALUE;
+    }
+};
+
+}
+
+}
+
+#endif

--- a/lib/Espfc/src/Hardware.h
+++ b/lib/Espfc/src/Hardware.h
@@ -14,6 +14,7 @@
 #include "Device/GyroDevice.h"
 #include "Device/GyroMPU6050.h"
 #include "Device/GyroMPU6500.h"
+#include "Device/GyroMPU6555.h"
 #include "Device/GyroMPU9250.h"
 #include "Device/GyroLSM6DSO.h"
 #include "Device/GyroICM20602.h"
@@ -25,6 +26,9 @@
 
 namespace {
 #if defined(ESPFC_SPI_0)
+#ifdef CONFIG_IDF_TARGET_ESP32S3
+  #define VSPI FSPI
+#endif
 #ifdef ESP32
   static SPIClass SPI1(VSPI);
 #endif
@@ -35,6 +39,7 @@ namespace {
 #endif
   static Espfc::Device::GyroMPU6050 mpu6050;
   static Espfc::Device::GyroMPU6500 mpu6500;
+  static Espfc::Device::GyroMPU6555 mpu6555;
   static Espfc::Device::GyroMPU9250 mpu9250;
   static Espfc::Device::GyroLSM6DSO lsm6dso;
   static Espfc::Device::GyroICM20602 icm20602;
@@ -91,6 +96,7 @@ class Hardware
         pinMode(_model.config.pin[PIN_SPI_CS0], OUTPUT);
         if(!detectedGyro && detectDevice(mpu9250, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu9250;
         if(!detectedGyro && detectDevice(mpu6500, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu6500;
+        if(!detectedGyro && detectDevice(mpu6555, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu6555;
         if(!detectedGyro && detectDevice(icm20602, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &icm20602;
         if(!detectedGyro && detectDevice(lsm6dso, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &lsm6dso;
       }
@@ -100,6 +106,7 @@ class Hardware
       {
         if(!detectedGyro && detectDevice(mpu9250, i2cBus)) detectedGyro = &mpu9250;
         if(!detectedGyro && detectDevice(mpu6500, i2cBus)) detectedGyro = &mpu6500;
+        if(!detectedGyro && detectDevice(mpu6555, i2cBus)) detectedGyro = &mpu6555;
         if(!detectedGyro && detectDevice(icm20602, i2cBus)) detectedGyro = &icm20602;
         if(!detectedGyro && detectDevice(mpu6050, i2cBus)) detectedGyro = &mpu6050;
         if(!detectedGyro && detectDevice(lsm6dso, i2cBus)) detectedGyro = &lsm6dso;


### PR DESCRIPTION
added support for MPU6555 ( the GY-9250 boards mentioned in #87 ) 
random drift every few seconds on the yaw axis is still present