### PR TITLE
add support for pyDrone hardware (https://github.com/01studio-lab/pyDrone)

### DIFF
--- a/docs/pyDrone_dump.txt
+++ b/docs/pyDrone_dump.txt
@@ -1,0 +1,280 @@
+# dump
+set features 536870920
+set debug_mode USB
+set debug_axis 1
+set gyro_bus AUTO
+set gyro_dev AUTO
+set gyro_dlpf 256Hz
+set gyro_align DEFAULT
+set gyro_lpf_type PT1
+set gyro_lpf_freq 100
+set gyro_lpf2_type PT1
+set gyro_lpf2_freq 213
+set gyro_lpf3_type FO
+set gyro_lpf3_freq 150
+set gyro_notch1_freq 0
+set gyro_notch1_cutoff 0
+set gyro_notch2_freq 0
+set gyro_notch2_cutoff 0
+set gyro_dyn_lpf_min 170
+set gyro_dyn_lpf_max 425
+set gyro_dyn_notch_q 300
+set gyro_dyn_notch_count 4
+set gyro_dyn_notch_min 80
+set gyro_dyn_notch_max 400
+set gyro_rpm_harmonics 3
+set gyro_rpm_q 500
+set gyro_rpm_min_freq 100
+set gyro_rpm_fade 30
+set gyro_rpm_weight_1 100
+set gyro_rpm_weight_2 100
+set gyro_rpm_weight_3 100
+set gyro_rpm_tlm_lpf_freq 150
+set gyro_offset_x -39
+set gyro_offset_y -17
+set gyro_offset_z -28
+set accel_bus AUTO
+set accel_dev AUTO
+set accel_lpf_type BIQUAD
+set accel_lpf_freq 15
+set accel_offset_x 261
+set accel_offset_y -44
+set accel_offset_z -1736
+set mag_bus AUTO
+set mag_dev AUTO
+set mag_align DEFAULT
+set mag_filter_type BIQUAD
+set mag_filter_lpf 10
+set mag_offset_x 0
+set mag_offset_y 0
+set mag_offset_z 0
+set mag_scale_x 1000
+set mag_scale_y 1000
+set mag_scale_z 1000
+set baro_bus AUTO
+set baro_dev AUTO
+set baro_lpf_type BIQUAD
+set baro_lpf_freq 10
+set vbat_source NONE
+set vbat_scale 100
+set vbat_mul 1
+set vbat_div 10
+set vbat_cell_warn 350
+set ibat_source NONE
+set ibat_scale 100
+set ibat_offset 0
+set fusion_mode MAHONY
+set fusion_gain_p 50
+set fusion_gain_i 5
+set input_rate_type ACTUAL
+set input_roll_rate 20
+set input_roll_srate 40
+set input_roll_expo 0
+set input_roll_limit 1998
+set input_pitch_rate 20
+set input_pitch_srate 40
+set input_pitch_expo 0
+set input_pitch_limit 1998
+set input_yaw_rate 30
+set input_yaw_srate 36
+set input_yaw_expo 0
+set input_yaw_limit 1998
+set input_deadband 3
+set input_min 885
+set input_mid 1500
+set input_max 2115
+set input_interpolation AUTO
+set input_interpolation_interval 26
+set input_filter_type FILTER
+set input_lpf_type PT3
+set input_lpf_freq 0
+set input_lpf_factor 50
+set input_ff_lpf_type PT3
+set input_ff_lpf_freq 0
+set input_rssi_channel 0
+set input_0 0 1000 1500 2000 A 1500
+set input_1 1 1000 1500 2000 A 1500
+set input_2 3 1000 1500 2000 A 1500
+set input_3 2 1000 1500 2000 A 1000
+set input_4 4 1000 1500 2000 H 1500
+set input_5 5 1000 1500 2000 H 1500
+set input_6 6 1000 1500 2000 H 1500
+set input_7 7 1000 1500 2000 H 1500
+set input_8 8 1000 1500 2000 H 1500
+set input_9 9 1000 1500 2000 H 1500
+set input_10 10 1000 1500 2000 H 1500
+set input_11 11 1000 1500 2000 H 1500
+set input_12 12 1000 1500 2000 H 1500
+set input_13 13 1000 1500 2000 H 1500
+set input_14 14 1000 1500 2000 H 1500
+set input_15 15 1000 1500 2000 H 1500
+set failsafe_delay 4
+set failsafe_kill_switch 0
+set serial_0 1 115200 0
+set serial_soft_0 1 115200 0
+set scaler_0 0 0 20 400
+set scaler_1 0 0 20 400
+set scaler_2 0 0 20 200
+set mode_0 0 4 900 900 70 71
+set mode_1 0 4 900 900 98 248
+set mode_2 0 4 900 900 31 212
+set mode_3 0 4 900 900 185 233
+set mode_4 0 4 900 900 70 62
+set mode_5 0 4 900 900 218 199
+set mode_6 0 4 900 900 169 103
+set mode_7 0 4 900 900 113 64
+set pid_sync 1
+set pid_roll_p 42
+set pid_roll_i 85
+set pid_roll_d 24
+set pid_roll_f 72
+set pid_pitch_p 46
+set pid_pitch_i 90
+set pid_pitch_d 26
+set pid_pitch_f 76
+set pid_yaw_p 45
+set pid_yaw_i 90
+set pid_yaw_d 0
+set pid_yaw_f 72
+set pid_level_p 55
+set pid_level_i 0
+set pid_level_d 0
+set pid_level_angle_limit 55
+set pid_level_rate_limit 300
+set pid_level_lpf_type PT1
+set pid_level_lpf_freq 90
+set pid_yaw_lpf_type PT1
+set pid_yaw_lpf_freq 90
+set pid_dterm_lpf_type PT1
+set pid_dterm_lpf_freq 128
+set pid_dterm_lpf2_type PT1
+set pid_dterm_lpf2_freq 128
+set pid_dterm_notch_freq 0
+set pid_dterm_notch_cutoff 0
+set pid_dterm_dyn_lpf_min 60
+set pid_dterm_dyn_lpf_max 145
+set pid_dterm_weight 30
+set pid_iterm_limit 30
+set pid_iterm_zero 1
+set pid_iterm_relax RP
+set pid_iterm_relax_cutoff 15
+set pid_tpa_scale 10
+set pid_tpa_breakpoint 1650
+set mixer_sync 1
+set mixer_type QUADX
+set mixer_yaw_reverse 1
+set mixer_throttle_limit_type NONE
+set mixer_throttle_limit_percent 100
+set mixer_output_limit 100
+set output_motor_protocol BRUSHED
+set output_motor_async 1
+set output_motor_rate 480
+set output_motor_poles 14
+set output_servo_rate 0
+set output_min_command 1000
+set output_min_throttle 1070
+set output_max_throttle 2000
+set output_dshot_idle 550
+set output_dshot_telemetry 0
+set output_0 M N 1000 1500 2000
+set output_1 M N 1000 1500 2000
+set output_2 M N 1000 1500 2000
+set output_3 M N 1000 1500 2000
+set pin_input_rx -1
+set pin_output_0 5
+set pin_output_1 4
+set pin_output_2 40
+set pin_output_3 41
+set pin_buzzer -1
+set pin_serial_0_tx 43
+set pin_serial_0_rx 44
+set pin_serial_1_tx -1
+set pin_serial_1_rx -1
+set pin_serial_2_tx -1
+set pin_serial_2_rx -1
+set pin_i2c_scl 15
+set pin_i2c_sda 16
+set pin_input_adc_0 2
+set pin_input_adc_1 -1
+set pin_spi_0_sck -1
+set pin_spi_0_mosi -1
+set pin_spi_0_miso -1
+set pin_spi_cs_0 -1
+set pin_spi_cs_1 -1
+set pin_spi_cs_2 -1
+set pin_buzzer_invert 1
+set i2c_speed 800
+set rescue_config_delay 30
+set telemetry_interval 1000
+set blackbox_dev 1
+set blackbox_mode NORMAL
+set blackbox_rate 32
+set blackbox_mask 0
+set wifi_ssid
+set wifi_pass
+set wifi_tcp_port 1111
+set mix_outputs 52
+set mix_0 0 0 0
+set mix_1 0 0 0
+set mix_2 0 0 0
+set mix_3 0 0 0
+set mix_4 0 0 0
+set mix_5 0 0 0
+set mix_6 0 0 0
+set mix_7 0 0 0
+set mix_8 0 0 0
+set mix_9 0 0 0
+set mix_10 0 0 0
+set mix_11 0 0 0
+set mix_12 0 0 0
+set mix_13 0 0 0
+set mix_14 0 0 0
+set mix_15 0 0 0
+set mix_16 0 0 0
+set mix_17 0 0 0
+set mix_18 0 0 0
+set mix_19 0 0 0
+set mix_20 0 0 0
+set mix_21 0 0 0
+set mix_22 0 0 0
+set mix_23 0 0 0
+set mix_24 0 0 0
+set mix_25 0 0 0
+set mix_26 0 0 0
+set mix_27 0 0 0
+set mix_28 0 0 0
+set mix_29 0 0 0
+set mix_30 0 0 0
+set mix_31 0 0 0
+set mix_32 0 0 0
+set mix_33 0 0 0
+set mix_34 0 0 0
+set mix_35 0 0 0
+set mix_36 0 0 0
+set mix_37 0 0 0
+set mix_38 0 0 0
+set mix_39 0 0 0
+set mix_40 0 0 0
+set mix_41 0 0 0
+set mix_42 0 0 0
+set mix_43 0 0 0
+set mix_44 0 0 0
+set mix_45 0 0 0
+set mix_46 0 0 0
+set mix_47 0 0 0
+set mix_48 0 0 0
+set mix_49 0 0 0
+set mix_50 0 0 0
+set mix_51 0 0 0
+set mix_52 0 0 0
+set mix_53 0 0 0
+set mix_54 0 0 0
+set mix_55 0 0 0
+set mix_56 0 0 0
+set mix_57 0 0 0
+set mix_58 0 0 0
+set mix_59 0 0 0
+set mix_60 0 0 0
+set mix_61 0 0 0
+set mix_62 0 0 0
+set mix_63 0 0 0

--- a/lib/Espfc/src/Device/BaroDevice.h
+++ b/lib/Espfc/src/Device/BaroDevice.h
@@ -12,6 +12,7 @@ enum BaroDeviceType {
   BARO_BMP085  = 2,
   BARO_MS5611  = 3,
   BARO_BMP280  = 4,
+  BARO_SPL06   = 5,
   BARO_MAX
 };
 
@@ -41,7 +42,7 @@ class BaroDevice: public BusAwareDevice
 
     static const char ** getNames()
     {
-      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("BMP085"), PSTR("MS5611"), PSTR("BMP280"), NULL };
+      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("BMP085"), PSTR("MS5611"), PSTR("BMP280"), PSTR("SPL06-001"), NULL };
       return devChoices;
     }
 

--- a/lib/Espfc/src/Device/BaroSPL06.h
+++ b/lib/Espfc/src/Device/BaroSPL06.h
@@ -167,6 +167,8 @@ class BaroSPL06: public BaroDevice
       float qua2, qua3;
       float fPCompensate;
 
+      readMesurment();
+
       fTsc = _raw_temp / (float)kt;
       fPsc = _raw_pressure / (float)kp;
       qua2 = _cal.c10 + fPsc * (_cal.c20 + fPsc* _cal.c30);
@@ -210,8 +212,12 @@ class BaroSPL06: public BaroDevice
     {
       uint8_t buffer[6] = {0, 0, 0, 0, 0, 0};
       _bus->readFast(_addr, SPL06_PRESSURE_REG, 6, buffer);
+
       _raw_pressure = buffer[2] | (buffer[1] << 8) | (buffer[0] << 16);
+      _raw_pressure = (_raw_pressure & 0x800000) ? (0xFF000000 | _raw_pressure) : _raw_pressure;
+
       _raw_temp = buffer[5] | (buffer[4] << 8) | (buffer[3] << 16);
+      _raw_temp = (_raw_temp & 0x800000) ? (0xFF000000 | _raw_temp) : _raw_temp;
     }
 
     int8_t writeReg(uint8_t reg, uint8_t val)

--- a/lib/Espfc/src/Device/BaroSPL06.h
+++ b/lib/Espfc/src/Device/BaroSPL06.h
@@ -1,0 +1,235 @@
+#ifndef _ESPFC_DEVICE_BARO_SPL06_H_
+#define _ESPFC_DEVICE_BARO_SPL06_H_
+
+#include "BusDevice.h"
+#include "BaroDevice.h"
+#include "Debug_Espfc.h"
+
+#define SPL06_ADDRESS_FIRST          0x76
+#define SPL06_ADDRESS_SECOND         0x77
+
+#define SPL06_WHOAMI_ID              0x10
+#define SPL06_WHOAMI_REG             0x0D
+
+#define SPL06_VERSION_REG            0xD1
+#define SPL06_RESET_REG              0x0C
+#define SPL06_RESET_VAL              0x89
+
+#define SPL06_CALIB_REG              0x10
+#define SPL06_CALIB_REG_COEF_LEN     18
+
+#define SPL06_PRESSURE_CFG_REG			(0x06)	/* Pressure configuration Reg */
+#define SPL06_TEMPERATURE_CFG_REG		(0x07)	/* Temperature configuration Reg */
+#define SPL06_MODE_CFG_REG				(0x08)  /* Mode and Status Configuration */
+#define SPL06_INT_FIFO_CFG_REG			(0x09)	/* Interrupt and FIFO Configuration */
+#define SPL06_INT_STATUS_REG			(0x0A)	/* Interrupt Status Reg */
+#define SPL06_FIFO_STATUS_REG			(0x0B)	/* FIFO Status Reg */
+#define SPL06_RST_REG					(0x0C)  /* Softreset Register */
+
+#define SPL06_PRESSURE_REG           0x00
+#define SPL06_TEMPERATURE_REG        0x03
+
+#define SPL06_DATA_FRAME_SIZE			(6)
+
+#define SPL06_CONTINUOUS_MODE			(0x07)
+
+#define TEMPERATURE_INTERNAL_SENSOR		(0)
+#define TEMPERATURE_EXTERNAL_SENSOR		(1)
+
+//测量次数 times / S
+#define SPL06_MWASURE_1					(0x00)
+#define SPL06_MWASURE_2					(0x01)
+#define SPL06_MWASURE_4					(0x02)
+#define SPL06_MWASURE_8					(0x03)
+#define SPL06_MWASURE_16				(0x04)
+#define SPL06_MWASURE_32				(0x05)
+#define SPL06_MWASURE_64				(0x06)
+#define SPL06_MWASURE_128				(0x07)
+
+//过采样率
+#define SPL06_OVERSAMP_1				(0x00)
+#define SPL06_OVERSAMP_2				(0x01)
+#define SPL06_OVERSAMP_4				(0x02)
+#define SPL06_OVERSAMP_8				(0x03)
+#define SPL06_OVERSAMP_16				(0x04)
+#define SPL06_OVERSAMP_32				(0x05)
+#define SPL06_OVERSAMP_64				(0x06)
+#define SPL06_OVERSAMP_128				(0x07)
+
+
+#define P_MEASURE_RATE 			SPL06_MWASURE_16 	//每秒测量次数
+#define P_OVERSAMP_RATE 		SPL06_OVERSAMP_64	//过采样率
+#define SPL06_PRESSURE_CFG		(P_MEASURE_RATE<<4 | P_OVERSAMP_RATE)
+
+#define T_MEASURE_RATE 			SPL06_MWASURE_16 	//每秒测量次数
+#define T_OVERSAMP_RATE 		SPL06_OVERSAMP_8	//过采样率
+#define SPL06_TEMPERATURE_CFG	(TEMPERATURE_EXTERNAL_SENSOR<<7 | T_MEASURE_RATE<<4 | T_OVERSAMP_RATE)
+
+#define SPL06_MODE				(SPL06_CONTINUOUS_MODE)
+#define  SPL06_TIME_MS	10
+const uint32_t scaleFactor[8] = {524288, 1572864, 3670016, 7864320, 253952, 516096, 1040384, 2088960};
+
+
+namespace Espfc {
+
+namespace Device {
+
+class BaroSPL06: public BaroDevice
+{
+  public:
+    struct CalibrationData {
+      int16_t c0;
+      int16_t c1;
+      int32_t c00;
+      int32_t c10;
+      int16_t c01;
+      int16_t c11;
+      int16_t c20;
+      int16_t c21;
+      int16_t c30;
+    } __attribute__ ((__packed__));
+
+    int begin(BusDevice * bus) override
+    {
+      return begin(bus, SPL06_ADDRESS_FIRST) ? 1 : begin(bus, SPL06_ADDRESS_SECOND) ? 1 : 0;
+    }
+
+    int begin(BusDevice * bus, uint8_t addr) override
+    {
+    
+      uint8_t buffer[SPL06_CALIB_REG_COEF_LEN] = {0};
+      
+      setBus(bus, addr);
+
+      if(!testConnection()) return 0;
+
+      writeReg(SPL06_RESET_REG, SPL06_RESET_VAL); // device reset
+      delay(50);
+
+      kt = 0;
+
+      kp = 0;
+
+      _bus->read(_addr, SPL06_CALIB_REG, SPL06_CALIB_REG_COEF_LEN, buffer); // read callibration
+	
+      _cal.c0 = (int16_t)buffer[0]<<4 | buffer[1]>>4;
+      _cal.c0 = (_cal.c0 & 0x0800) ? (_cal.c0 | 0xF000) : _cal.c0;
+    	
+      _cal.c1 = (int16_t)(buffer[1] & 0x0F)<<8 | buffer[2];
+      _cal.c1 = (_cal.c1 & 0x0800) ? (_cal.c1 | 0xF000) : _cal.c1;
+    	
+      _cal.c00 = (int32_t)buffer[3]<<12 | (int32_t)buffer[4]<<4 | (int32_t)buffer[5]>>4;
+      _cal.c00 = (_cal.c00 & 0x080000) ? (_cal.c00 | 0xFFF00000) : _cal.c00;
+    	
+      _cal.c10 = (int32_t)(buffer[5] & 0x0F)<<16 | (int32_t)buffer[6]<<8 | (int32_t)buffer[7];
+      _cal.c10 = (_cal.c10 & 0x080000) ? (_cal.c10 | 0xFFF00000) : _cal.c10;
+    	
+      _cal.c01 = (int16_t)buffer[8]<<8 | buffer[9];
+      _cal.c11 = (int16_t)buffer[10]<<8 | buffer[11];
+      _cal.c20 = (int16_t)buffer[12]<<8 | buffer[13];
+      _cal.c21 = (int16_t)buffer[14]<<8 | buffer[15];
+      _cal.c30 = (int16_t)buffer[16]<<8 | buffer[17];
+
+      kp = scaleFactor[SPL06_OVERSAMP_64];
+	  writeReg(SPL06_PRESSURE_CFG_REG, SPL06_MWASURE_16<<4 | SPL06_OVERSAMP_64);
+
+
+      kt = scaleFactor[SPL06_OVERSAMP_64];
+      writeReg(SPL06_TEMPERATURE_CFG_REG, SPL06_MWASURE_16<<4 | SPL06_OVERSAMP_64 | 0x80);//Using mems temperature
+      writeReg(SPL06_INT_FIFO_CFG_REG, 0x04 | 0x08);
+
+      writeReg(SPL06_MODE_CFG_REG, SPL06_MODE); // set sampling mode
+
+      delay(20);
+
+      return 1;
+    }
+
+    BaroDeviceType getType() const override
+    {
+      return BARO_SPL06;
+    }
+
+    virtual float readTemperature() override
+    {
+      float fTCompensate;
+      float fTsc;
+
+      fTsc = _raw_temp / (float)kt;
+      fTCompensate =  _cal.c0 * 0.5 + _cal.c1 * fTsc;
+
+      return fTCompensate;
+    }
+
+    virtual float readPressure() override
+    {
+      float fTsc, fPsc;
+      float qua2, qua3;
+      float fPCompensate;
+
+      fTsc = _raw_temp / (float)kt;
+      fPsc = _raw_pressure / (float)kp;
+      qua2 = _cal.c10 + fPsc * (_cal.c20 + fPsc* _cal.c30);
+      qua3 = fTsc * fPsc * (_cal.c11 + fPsc * _cal.c21);
+	  //qua3 = 0.9f *fTsc * fPsc * (spl06Calib.c11 + fPsc * spl06Calib.c21);
+
+      fPCompensate = _cal.c00 + fPsc * qua2 + fTsc * _cal.c01 + qua3;
+	  //fPCompensate = spl06Calib.c00 + fPsc * qua2 + 0.9f *fTsc  * spl06Calib.c01 + qua3;
+      return fPCompensate;
+
+      
+    }
+
+    void setMode(BaroDeviceMode mode)
+    {
+      (void)mode;
+    }
+
+    virtual int getDelay(BaroDeviceMode mode) const override
+    {
+      switch(mode)
+      {
+        case BARO_MODE_TEMP:
+          return 0;
+        default:
+          //return 5500; // if sapling X1
+          //return 7500; // if sampling X2
+          return 11500;  // if sampling X4
+      }
+    }
+
+    bool testConnection() override
+    {
+      uint8_t whoami = 0;
+      _bus->read(_addr, SPL06_WHOAMI_REG, 1, &whoami);
+      return whoami == SPL06_WHOAMI_ID;
+    }
+
+  protected:
+    void readMesurment()
+    {
+      uint8_t buffer[6] = {0, 0, 0, 0, 0, 0};
+      _bus->readFast(_addr, SPL06_PRESSURE_REG, 6, buffer);
+      _raw_pressure = buffer[2] | (buffer[1] << 8) | (buffer[0] << 16);
+      _raw_temp = buffer[5] | (buffer[4] << 8) | (buffer[3] << 16);
+    }
+
+    int8_t writeReg(uint8_t reg, uint8_t val)
+    {
+      return _bus->write(_addr, reg, 1, &val);
+    }
+
+    int8_t _mode;
+    int32_t _t_fine;
+    int32_t _raw_temp;
+    int32_t _raw_pressure;
+    CalibrationData _cal;
+    int32_t kp;
+    int32_t kt;
+};
+
+}
+
+}
+
+#endif

--- a/lib/Espfc/src/Device/MagDevice.h
+++ b/lib/Espfc/src/Device/MagDevice.h
@@ -12,6 +12,7 @@ enum MagDeviceType {
   MAG_HMC5883 = 2,
   MAG_AK8975  = 3,
   MAG_AK8963  = 4,
+  MAG_QMC5883 = 5,
   MAG_MAX
 };
 
@@ -35,7 +36,7 @@ class MagDevice: public BusAwareDevice
 
     static const char ** getNames()
     {
-      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("HMC5883L"), PSTR("AK8975"), PSTR("AK8963"), NULL };
+      static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("HMC5883L"), PSTR("AK8975"), PSTR("AK8963"), PSTR("QMC5883L"),NULL };
       return devChoices;
     }
 

--- a/lib/Espfc/src/Device/MagQMC5338L.h
+++ b/lib/Espfc/src/Device/MagQMC5338L.h
@@ -1,0 +1,130 @@
+#ifndef _ESPFC_DEVICE_MAG_QMC5338L_H_
+#define _ESPFC_DEVICE_MAG_QMC5338L_H_
+
+#include "MagDevice.h"
+#include "BusDevice.h"
+
+#define QMC5883L_ADDRESS            0x0D // this device only has one address
+#define QMC5883L_DEFAULT_ADDRESS    0x0D
+
+#define QMC5883L_RA_CONFIG_A        0x09
+#define QMC5883L_RA_CONFIG_B        0x0A
+#define QMC5883L_RA_MODE            0x09
+
+#define QMC5883L_RA_STATUS          0x06
+
+#define QMC5883L_RA_DATAX_H         0x01
+#define QMC5883L_RA_DATAX_L         0x00
+#define QMC5883L_RA_DATAZ_H         0x05
+#define QMC5883L_RA_DATAZ_L         0x04
+#define QMC5883L_RA_DATAY_H         0x03
+#define QMC5883L_RA_DATAY_L         0x02
+
+#define QMC5883L_RA_TEMP_L          0x07
+#define QMC5883L_RA_TEMP_H          0x08
+
+#define QMC5883L_RA_RST_TIME        0x0B
+#define QMC5883L_RA_RSV             0x0C
+#define QMC5883L_RA_CHIPID          0x0D
+
+#define QMC5883L_RATE_10            0x00
+#define QMC5883L_RATE_50            0x01
+#define QMC5883L_RATE_100           0x02
+#define QMC5883L_RATE_200           0x03
+
+#define QMC5883L_RANGE_2G           0x00
+#define QMC5883L_RANGE_8G           0x01
+
+#define QMC5883L_OSR_512            0x00
+#define QMC5883L_OSR_256            0x01
+#define QMC5883L_OSR_128            0x02
+#define QMC5883L_OSR_64             0x03
+
+#define QMC5883L_MODE_CONTINUOUS    0x01
+#define QMC5883L_MODE_IDLE          0x00
+
+#define QMC5883L_STATUS_LOCK_BIT    1
+#define QMC5883L_STATUS_READY_BIT   0
+
+
+namespace Espfc {
+
+namespace Device {
+
+class MagQMC5338L: public MagDevice
+{
+  public:
+    int begin(BusDevice * bus) override
+    {
+      return begin(bus, QMC5883L_DEFAULT_ADDRESS);
+    }
+
+    int begin(BusDevice * bus, uint8_t addr) override
+    {
+      setBus(bus, addr);
+
+      if(!testConnection()) return 0;
+
+      setMode(QMC5883L_OSR_64, QMC5883L_RANGE_2G, QMC5883L_RATE_100, QMC5883L_MODE_CONTINUOUS);
+
+      uint8_t buffer[6];
+      _bus->read(_addr, QMC5883L_RA_DATAX_H, 6, buffer);
+
+      return 1;
+    }
+
+    int readMag(VectorInt16& v) override
+    {
+      uint8_t buffer[6];
+      _bus->readFast(_addr, QMC5883L_RA_DATAX_L, 6, buffer);
+
+      v.x = (((int16_t)buffer[1]) << 8) | buffer[0];
+
+      v.y = (((int16_t)buffer[3]) << 8) | buffer[2];
+
+      v.z = (((int16_t)buffer[5]) << 8) | buffer[4];
+
+      return 1;
+    }
+
+    const VectorFloat convert(const VectorInt16& v) const override
+    {
+      const float scale = 1.f / 1090.f;
+      return VectorFloat{v} * scale;
+    }
+
+    int getRate() const override
+    {
+      return 75;
+    }
+
+    virtual MagDeviceType getType() const override
+    {
+      return MAG_QMC5883;
+    }
+
+    void setMode(uint8_t osr, uint8_t rng, uint8_t odr, uint8_t mode)
+    {
+      _mode = (osr << 6) | (rng << 4) | (odr << 2) | (mode);
+      uint8_t res = _bus->writeByte(_addr, QMC5883L_RA_MODE, ((osr << 6) | (rng << 4) | (odr << 2) | (mode)));
+
+      (void)res;
+    }
+
+    bool testConnection() override
+    {
+      uint8_t buffer[3] = { 0, 0, 0 };
+      uint8_t len = _bus->read(_addr, QMC5883L_RA_CHIPID, 1, buffer);
+
+      return len == 1 && buffer[0] == 0xFF;
+    }
+
+  private:
+    uint8_t _mode;
+};
+
+}
+
+}
+
+#endif

--- a/lib/Espfc/src/Hardware.h
+++ b/lib/Espfc/src/Hardware.h
@@ -24,10 +24,13 @@
 #include "Device/GyroICM20602.h"
 #include "Device/GyroBMI160.h"
 #include "Device/MagHMC5338L.h"
+#include "Device/MagQMC5338L.h"
 #include "Device/MagAK8963.h"
 #include "Device/BaroDevice.h"
 #include "Device/BaroBMP085.h"
 #include "Device/BaroBMP280.h"
+#include "Device/BaroSPL06.h"
+
 
 namespace {
 #if defined(ESPFC_SPI_0)
@@ -49,9 +52,11 @@ namespace {
   static Espfc::Device::GyroICM20602 icm20602;
   static Espfc::Device::GyroBMI160 bmi160;
   static Espfc::Device::MagHMC5338L hmc5883l;
+  static Espfc::Device::MagQMC5338L qmc5883l;
   static Espfc::Device::MagAK8963 ak8963;
   static Espfc::Device::BaroBMP085 bmp085;
   static Espfc::Device::BaroBMP280 bmp280;
+  static Espfc::Device::BaroSPL06 spl06;
 }
 
 namespace Espfc {
@@ -138,12 +143,15 @@ class Hardware
       {
         if(!detectedMag && detectDevice(ak8963, i2cBus)) detectedMag = &ak8963;
         if(!detectedMag && detectDevice(hmc5883l, i2cBus)) detectedMag = &hmc5883l;
+        if(!detectedMag && detectDevice(qmc5883l, i2cBus)) detectedMag = &qmc5883l;
       }
 #endif
       if(gyroSlaveBus.getBus())
       {
         if(!detectedMag && detectDevice(ak8963, gyroSlaveBus)) detectedMag = &ak8963;
         if(!detectedMag && detectDevice(hmc5883l, gyroSlaveBus)) detectedMag = &hmc5883l;
+        if(!detectedMag && detectDevice(qmc5883l, gyroSlaveBus)) detectedMag = &qmc5883l;
+        
       }
       _model.state.magDev = detectedMag;
       _model.state.magPresent = (bool)detectedMag;
@@ -162,6 +170,7 @@ class Hardware
         pinMode(_model.config.pin[PIN_SPI_CS1], OUTPUT);
         if(!detectedBaro && detectDevice(bmp280, spiBus, _model.config.pin[PIN_SPI_CS1])) detectedBaro = &bmp280;
         if(!detectedBaro && detectDevice(bmp085, spiBus, _model.config.pin[PIN_SPI_CS1])) detectedBaro = &bmp085;
+        if(!detectedBaro && detectDevice(spl06, spiBus, _model.config.pin[PIN_SPI_CS1])) detectedBaro = &spl06;
       }
 #endif
 #if defined(ESPFC_I2C_0)
@@ -169,8 +178,16 @@ class Hardware
       {
         if(!detectedBaro && detectDevice(bmp280, i2cBus)) detectedBaro = &bmp280;
         if(!detectedBaro && detectDevice(bmp085, i2cBus)) detectedBaro = &bmp085;
+        if(!detectedBaro && detectDevice(spl06, i2cBus)) detectedBaro = &spl06;
       }
 #endif
+      if(gyroSlaveBus.getBus())
+      {
+        if(!detectedBaro && detectDevice(bmp280, gyroSlaveBus)) detectedBaro = &bmp280;
+        if(!detectedBaro && detectDevice(bmp085, gyroSlaveBus)) detectedBaro = &bmp085;
+        if(!detectedBaro && detectDevice(spl06, gyroSlaveBus)) detectedBaro = &spl06;
+      }
+
       _model.state.baroDev = detectedBaro;
       _model.state.baroPresent = (bool)detectedBaro;
     }

--- a/lib/Espfc/src/Target/TargetESP32s3.h
+++ b/lib/Espfc/src/Target/TargetESP32s3.h
@@ -9,13 +9,13 @@
 // usb/jtag: 19, 20
 
 #define ESPFC_INPUT
-#define ESPFC_INPUT_PIN 6 // ppm
+#define ESPFC_INPUT_PIN -1 // ppm
 
 #define ESPFC_OUTPUT_COUNT 4
-#define ESPFC_OUTPUT_0 39
-#define ESPFC_OUTPUT_1 40
-#define ESPFC_OUTPUT_2 41
-#define ESPFC_OUTPUT_3 42
+#define ESPFC_OUTPUT_0 5
+#define ESPFC_OUTPUT_1 4
+#define ESPFC_OUTPUT_2 40
+#define ESPFC_OUTPUT_3 41
 
 #define ESPFC_SERIAL_0
 #define ESPFC_SERIAL_0_DEV Serial0
@@ -26,7 +26,7 @@
 #define ESPFC_SERIAL_0_BAUD (SERIAL_SPEED_115200)
 #define ESPFC_SERIAL_0_BBAUD (SERIAL_SPEED_NONE)
 
-#define ESPFC_SERIAL_1
+//#define ESPFC_SERIAL_1
 #define ESPFC_SERIAL_1_DEV Serial1
 #define ESPFC_SERIAL_1_DEV_T HardwareSerial
 #define ESPFC_SERIAL_1_TX 16
@@ -35,7 +35,7 @@
 #define ESPFC_SERIAL_1_BAUD (SERIAL_SPEED_115200)
 #define ESPFC_SERIAL_1_BBAUD (SERIAL_SPEED_NONE)
 
-#define ESPFC_SERIAL_2
+//#define ESPFC_SERIAL_2
 #define ESPFC_SERIAL_2_DEV Serial2
 #define ESPFC_SERIAL_2_DEV_T HardwareSerial
 #define ESPFC_SERIAL_2_TX 18
@@ -57,7 +57,7 @@
 #define ESPFC_SERIAL_DEBUG_PORT SERIAL_USB
 #define SERIAL_TX_FIFO_SIZE 0xFF
 
-#define ESPFC_SPI_0
+//#define ESPFC_SPI_0
 #define ESPFC_SPI_0_DEV SPI1
 #define ESPFC_SPI_0_SCK 12
 #define ESPFC_SPI_0_MOSI 11
@@ -67,17 +67,17 @@
 #define ESPFC_SPI_CS_BARO 7
 
 #define ESPFC_I2C_0
-#define ESPFC_I2C_0_SCL 10
-#define ESPFC_I2C_0_SDA 9
+#define ESPFC_I2C_0_SCL 15
+#define ESPFC_I2C_0_SDA 16
 #define ESPFC_I2C_0_SOFT
 
-#define ESPFC_BUZZER
+//#define ESPFC_BUZZER
 #define ESPFC_BUZZER_PIN 5
 
 #define ESPFC_ADC_0
-#define ESPFC_ADC_0_PIN 1
+#define ESPFC_ADC_0_PIN 2
 
-#define ESPFC_ADC_1
+//#define ESPFC_ADC_1
 #define ESPFC_ADC_1_PIN 4
 
 #define ESPFC_ADC_SCALE (3.3f / 4096)

--- a/lib/Espfc/src/Target/TargetESP32s3.h
+++ b/lib/Espfc/src/Target/TargetESP32s3.h
@@ -9,13 +9,13 @@
 // usb/jtag: 19, 20
 
 #define ESPFC_INPUT
-#define ESPFC_INPUT_PIN -1 // ppm
+#define ESPFC_INPUT_PIN 6 // ppm
 
 #define ESPFC_OUTPUT_COUNT 4
-#define ESPFC_OUTPUT_0 5
-#define ESPFC_OUTPUT_1 4
-#define ESPFC_OUTPUT_2 40
-#define ESPFC_OUTPUT_3 41
+#define ESPFC_OUTPUT_0 39
+#define ESPFC_OUTPUT_1 40
+#define ESPFC_OUTPUT_2 41
+#define ESPFC_OUTPUT_3 42
 
 #define ESPFC_SERIAL_0
 #define ESPFC_SERIAL_0_DEV Serial0
@@ -26,7 +26,7 @@
 #define ESPFC_SERIAL_0_BAUD (SERIAL_SPEED_115200)
 #define ESPFC_SERIAL_0_BBAUD (SERIAL_SPEED_NONE)
 
-//#define ESPFC_SERIAL_1
+#define ESPFC_SERIAL_1
 #define ESPFC_SERIAL_1_DEV Serial1
 #define ESPFC_SERIAL_1_DEV_T HardwareSerial
 #define ESPFC_SERIAL_1_TX 16
@@ -35,7 +35,7 @@
 #define ESPFC_SERIAL_1_BAUD (SERIAL_SPEED_115200)
 #define ESPFC_SERIAL_1_BBAUD (SERIAL_SPEED_NONE)
 
-//#define ESPFC_SERIAL_2
+#define ESPFC_SERIAL_2
 #define ESPFC_SERIAL_2_DEV Serial2
 #define ESPFC_SERIAL_2_DEV_T HardwareSerial
 #define ESPFC_SERIAL_2_TX 18
@@ -57,7 +57,7 @@
 #define ESPFC_SERIAL_DEBUG_PORT SERIAL_USB
 #define SERIAL_TX_FIFO_SIZE 0xFF
 
-//#define ESPFC_SPI_0
+#define ESPFC_SPI_0
 #define ESPFC_SPI_0_DEV SPI1
 #define ESPFC_SPI_0_SCK 12
 #define ESPFC_SPI_0_MOSI 11
@@ -67,17 +67,17 @@
 #define ESPFC_SPI_CS_BARO 7
 
 #define ESPFC_I2C_0
-#define ESPFC_I2C_0_SCL 15
-#define ESPFC_I2C_0_SDA 16
+#define ESPFC_I2C_0_SCL 10
+#define ESPFC_I2C_0_SDA 9
 #define ESPFC_I2C_0_SOFT
 
-//#define ESPFC_BUZZER
+#define ESPFC_BUZZER
 #define ESPFC_BUZZER_PIN 5
 
 #define ESPFC_ADC_0
-#define ESPFC_ADC_0_PIN 2
+#define ESPFC_ADC_0_PIN 1
 
-//#define ESPFC_ADC_1
+#define ESPFC_ADC_1
 #define ESPFC_ADC_1_PIN 4
 
 #define ESPFC_ADC_SCALE (3.3f / 4096)


### PR DESCRIPTION
pyDrone has a ESP32-S3-WROOM core, with MPU6050 QMC5883L and SPL06-001 sensor chips.
QMC5883L and SPL06-001 connected with MPU6050L AUX I2C.