### PR TITLE
fixed crsf telemetry

### DIFF
--- a/lib/Espfc/src/SerialManager.cpp
+++ b/lib/Espfc/src/SerialManager.cpp
@@ -146,31 +146,41 @@ int FAST_CODE_ATTR SerialManager::update()
   const SerialPortConfig& sc = _model.config.serial[_current];
   SerialPortState& ss = _model.state.serial[_current];
 
-  if(ss.stream && !(sc.functionMask & SERIAL_FUNCTION_RX_SERIAL))
+  if(ss.stream)
   {
-    Utils::Stats::Measure measure(_model.state.stats, COUNTER_SERIAL);
-    if (sc.functionMask & SERIAL_FUNCTION_MSP)
+    if((sc.functionMask & SERIAL_FUNCTION_RX_SERIAL) && _model.config.input.serialRxProvider == SERIALRX_CRSF)
     {
-      processMsp(ss);
+      if(_model.config.featureMask & FEATURE_TELEMETRY)
+      {
+        _telemetry.process(*ss.stream, TELEMETRY_PROTOCOL_CRSF);
+      }
     }
-    if(sc.functionMask & SERIAL_FUNCTION_TELEMETRY_FRSKY && _model.state.telemetryTimer.check())
+
+    if(ss.stream && !(sc.functionMask & SERIAL_FUNCTION_RX_SERIAL))
     {
-      _telemetry.process(*ss.stream, TELEMETRY_PROTOCOL_TEXT);
-    }
-    if(sc.functionMask & SERIAL_FUNCTION_TELEMETRY_IBUS)
-    {
-      _ibus.update();
-    }
-    if(sc.functionMask & SERIAL_FUNCTION_VTX_SMARTAUDIO)
-    {
-      _vtx.update();
-    }
-    if(sc.functionMask & SERIAL_FUNCTION_GPS)
-    {
-      _gps.update();
+      Utils::Stats::Measure measure(_model.state.stats, COUNTER_SERIAL);
+      if(sc.functionMask & SERIAL_FUNCTION_MSP)
+      {
+        processMsp(ss);
+      }
+      if(sc.functionMask & SERIAL_FUNCTION_TELEMETRY_FRSKY && _model.state.telemetryTimer.check())
+      {
+        _telemetry.process(*ss.stream, TELEMETRY_PROTOCOL_TEXT);
+      }
+      if(sc.functionMask & SERIAL_FUNCTION_TELEMETRY_IBUS)
+      {
+        _ibus.update();
+      }
+      if(sc.functionMask & SERIAL_FUNCTION_VTX_SMARTAUDIO)
+      {
+        _vtx.update();
+      }
+      if(sc.functionMask & SERIAL_FUNCTION_GPS)
+      {
+        _gps.update();
+      }
     }
   }
-
 #ifdef ESPFC_SERIAL_SOFT_0_WIFI
   if(_current == SERIAL_SOFT_0)
   {

--- a/lib/Espfc/src/Telemetry/TelemetryCRSF.h
+++ b/lib/Espfc/src/Telemetry/TelemetryCRSF.h
@@ -133,14 +133,32 @@ public:
   void flightMode(Rc::CrsfMessage& msg) const
   {
     msg.prepare(Rc::CRSF_FRAMETYPE_FLIGHT_MODE);
+    char buf[20] = ""; 
+    
+    if(_model.isModeActive(MODE_FAILSAFE))
+    {
+      strcpy(buf, "FAILSAFE");
+    }    
+    else if (!_model.isModeActive(MODE_ARMED))
+    {
+      strcpy(buf, "DISARM");
+    }     
+    else {
+      strcpy(buf, "ARM");      
+      if (_model.isModeActive(MODE_AIRMODE)) 
+      {
+        strcat(buf, "-AIR");
+      }     
+      if (_model.isModeActive(MODE_ANGLE)) 
+      {
+        strcat(buf, "-ANGL");
+      } else {
+        strcat(buf, "-ACRO");
+      }
+    }
 
-    if(_model.armingDisabled()) msg.writeString("!DIS");
-    if(_model.isModeActive(MODE_FAILSAFE)) msg.writeString("!FS,");
-    if(_model.isModeActive(MODE_ARMED)) msg.writeString("ARM,");
-    if(_model.isModeActive(MODE_AIRMODE)) msg.writeString("AIR,");
-    if(_model.isModeActive(MODE_ANGLE)) msg.writeString("STAB,");
-    msg.writeU8(0);
-
+    msg.writeString(buf);
+    msg.writeU8(0); 
     msg.finalize();
   }
 


### PR DESCRIPTION
CRSF Telemetry was not working at all. Fixed and also modified the Flight Mode data that is provided via telemetry so that multiple modes can be displayed at the same time. Example: Arm-Air-Angl