### PR TITLE
feat(gps): replace CFG-GNSS with CFG-VALSET for PROTVER > 23.01

### DIFF
--- a/lib/Espfc/src/ModelState.h
+++ b/lib/Espfc/src/ModelState.h
@@ -360,6 +360,7 @@ struct GpsSupportState
   bool sbas = false;
   bool qzss = false;
   bool dualBand = false;
+  uint8_t protVerMajor = 0; // parsed from MON-VER "PROTVER=XX.XX" ext string
 };
 
 template<typename T>

--- a/lib/Espfc/src/Sensor/GpsSensor.cpp
+++ b/lib/Espfc/src/Sensor/GpsSensor.cpp
@@ -328,8 +328,7 @@ void GpsSensor::handleError() const
 
 void GpsSensor::configureGnssValset()
 {
-  const auto version = _model.state.gps.support.version;
-  const bool useDualBand = (_model.config.gps.enableDualBand && version == GPS_M10);
+  const bool useDualBand = _model.config.gps.enableDualBand && _model.state.gps.support.dualBand;
 
   bool enableGPS  = _model.config.gps.enableGPS;
   bool enableGLO  = _model.config.gps.enableGLONASS;
@@ -347,9 +346,9 @@ void GpsSensor::configureGnssValset()
     case 5: enableGPS = enableGLO = enableGAL = enableBDS = enableQZSS = true; break;
   }
 
-  Gps::UbxCfgValsetSignal msg{};
+  Gps::UbxCfgValset<8> msg{};
   msg.version = 0;
-  msg.layers  = 0x07; // RAM + BBR + Flash
+  msg.layers  = 0x01; // RAM only
   msg.kv[0] = { Gps::CFG_SIGNAL_GPS_ENA,  (uint8_t)(enableGPS  ? 1 : 0) };
   msg.kv[1] = { Gps::CFG_SIGNAL_SBAS_ENA, (uint8_t)(enableSBAS ? 1 : 0) };
   msg.kv[2] = { Gps::CFG_SIGNAL_GAL_ENA,  (uint8_t)(enableGAL  ? 1 : 0) };
@@ -375,7 +374,7 @@ void GpsSensor::configureGnssValset()
 
 void GpsSensor::configureGnss()
 {
-  if (_model.state.gps.support.protVerMajor > 23)
+  if (_model.state.gps.support.protVerMajor >= 27)
   {
     configureGnssValset();
     return;

--- a/lib/Espfc/src/Sensor/GpsSensor.cpp
+++ b/lib/Espfc/src/Sensor/GpsSensor.cpp
@@ -350,14 +350,14 @@ void GpsSensor::configureGnssValset()
   Gps::UbxCfgValsetSignal msg{};
   msg.version = 0;
   msg.layers  = 0x07; // RAM + BBR + Flash
-  msg.kv[0] = { Gps::CFG_SIGNAL_GPS_ENA,  enableGPS  ? 1u : 0u };
-  msg.kv[1] = { Gps::CFG_SIGNAL_SBAS_ENA, enableSBAS ? 1u : 0u };
-  msg.kv[2] = { Gps::CFG_SIGNAL_GAL_ENA,  enableGAL  ? 1u : 0u };
-  msg.kv[3] = { Gps::CFG_SIGNAL_BDS_ENA,  enableBDS  ? 1u : 0u };
-  msg.kv[4] = { Gps::CFG_SIGNAL_QZSS_ENA, enableQZSS ? 1u : 0u };
-  msg.kv[5] = { Gps::CFG_SIGNAL_GLO_ENA,  enableGLO  ? 1u : 0u };
-  msg.kv[6] = { Gps::CFG_SIGNAL_GPS_L5,   useDualBand ? 1u : 0u };
-  msg.kv[7] = { Gps::CFG_SIGNAL_BDS_B2A,  useDualBand ? 1u : 0u };
+  msg.kv[0] = { Gps::CFG_SIGNAL_GPS_ENA,  (uint8_t)(enableGPS  ? 1 : 0) };
+  msg.kv[1] = { Gps::CFG_SIGNAL_SBAS_ENA, (uint8_t)(enableSBAS ? 1 : 0) };
+  msg.kv[2] = { Gps::CFG_SIGNAL_GAL_ENA,  (uint8_t)(enableGAL  ? 1 : 0) };
+  msg.kv[3] = { Gps::CFG_SIGNAL_BDS_ENA,  (uint8_t)(enableBDS  ? 1 : 0) };
+  msg.kv[4] = { Gps::CFG_SIGNAL_QZSS_ENA, (uint8_t)(enableQZSS ? 1 : 0) };
+  msg.kv[5] = { Gps::CFG_SIGNAL_GLO_ENA,  (uint8_t)(enableGLO  ? 1 : 0) };
+  msg.kv[6] = { Gps::CFG_SIGNAL_GPS_L5,   (uint8_t)(useDualBand ? 1 : 0) };
+  msg.kv[7] = { Gps::CFG_SIGNAL_BDS_B2A,  (uint8_t)(useDualBand ? 1 : 0) };
 
   _model.logger.info().log(F("GPS VALSET "));
   if (useDualBand) _model.logger.info().log(F("L1+L5 "));

--- a/lib/Espfc/src/Sensor/GpsSensor.cpp
+++ b/lib/Espfc/src/Sensor/GpsSensor.cpp
@@ -2,6 +2,7 @@
 #include <GpsProtocol.hpp>
 #include <Arduino.h>
 #include <cmath>
+#include <cstdlib>
 #include <tuple>
 
 namespace Espfc::Sensor
@@ -325,8 +326,61 @@ void GpsSensor::handleError() const
   _model.state.gps.present = false;
 }
 
+void GpsSensor::configureGnssValset()
+{
+  const auto version = _model.state.gps.support.version;
+  const bool useDualBand = (_model.config.gps.enableDualBand && version == GPS_M10);
+
+  bool enableGPS  = _model.config.gps.enableGPS;
+  bool enableGLO  = _model.config.gps.enableGLONASS;
+  bool enableGAL  = _model.config.gps.enableGalileo;
+  bool enableBDS  = _model.config.gps.enableBeiDou;
+  bool enableQZSS = _model.config.gps.enableQZSS;
+  bool enableSBAS = _model.config.gps.enableSBAS;
+
+  switch (_model.config.gps.gnssMode)
+  {
+    case 1: enableGPS = true; enableGLO = enableGAL = enableBDS = enableQZSS = false; break;
+    case 2: enableGPS = enableGLO = true; enableGAL = enableBDS = enableQZSS = false; break;
+    case 3: enableGPS = enableGAL = true; enableGLO = enableBDS = enableQZSS = false; break;
+    case 4: enableGPS = enableBDS = true; enableGLO = enableGAL = enableQZSS = false; break;
+    case 5: enableGPS = enableGLO = enableGAL = enableBDS = enableQZSS = true; break;
+  }
+
+  Gps::UbxCfgValsetSignal msg{};
+  msg.version = 0;
+  msg.layers  = 0x07; // RAM + BBR + Flash
+  msg.kv[0] = { Gps::CFG_SIGNAL_GPS_ENA,  enableGPS  ? 1u : 0u };
+  msg.kv[1] = { Gps::CFG_SIGNAL_SBAS_ENA, enableSBAS ? 1u : 0u };
+  msg.kv[2] = { Gps::CFG_SIGNAL_GAL_ENA,  enableGAL  ? 1u : 0u };
+  msg.kv[3] = { Gps::CFG_SIGNAL_BDS_ENA,  enableBDS  ? 1u : 0u };
+  msg.kv[4] = { Gps::CFG_SIGNAL_QZSS_ENA, enableQZSS ? 1u : 0u };
+  msg.kv[5] = { Gps::CFG_SIGNAL_GLO_ENA,  enableGLO  ? 1u : 0u };
+  msg.kv[6] = { Gps::CFG_SIGNAL_GPS_L5,   useDualBand ? 1u : 0u };
+  msg.kv[7] = { Gps::CFG_SIGNAL_BDS_B2A,  useDualBand ? 1u : 0u };
+
+  _model.logger.info().log(F("GPS VALSET "));
+  if (useDualBand) _model.logger.info().log(F("L1+L5 "));
+  _model.logger.info().log(F("["));
+  if (enableGPS)  _model.logger.info().log(F("GPS "));
+  if (enableGLO)  _model.logger.info().log(F("GLO "));
+  if (enableGAL)  _model.logger.info().log(F("GAL "));
+  if (enableBDS)  _model.logger.info().log(F("BDS "));
+  if (enableQZSS) _model.logger.info().log(F("QZSS "));
+  if (enableSBAS) _model.logger.info().log(F("SBAS"));
+  _model.logger.info().logln(F("]"));
+
+  send(msg, SET_RATE, SET_RATE);
+}
+
 void GpsSensor::configureGnss()
 {
+  if (_model.state.gps.support.protVerMajor > 23)
+  {
+    configureGnssValset();
+    return;
+  }
+
   const auto version = _model.state.gps.support.version;
   const bool useDualBand = (_model.config.gps.enableDualBand && version == GPS_M10);
 
@@ -395,7 +449,7 @@ void GpsSensor::configureGnss()
   if (enableSBAS) _model.logger.info().log(F("SBAS"));
   _model.logger.info().logln(F("]"));
 
-  send(gnss, SET_RATE, SET_RATE); // on NAK (CFG-GNSS deprecated >PROTVER 23.01), skip to SET_RATE instead of ERROR
+  send(gnss, SET_RATE);
 }
 
 void GpsSensor::calculateHomeVector() const
@@ -562,6 +616,11 @@ void GpsSensor::checkSupport(const char *payload) const
   if (std::strstr(payload, "QZSS") != nullptr)
   {
     _model.state.gps.support.qzss = true;
+  }
+  const char* pv = std::strstr(payload, "PROTVER=");
+  if (pv != nullptr)
+  {
+    _model.state.gps.support.protVerMajor = (uint8_t)std::atoi(pv + 8);
   }
 }
 

--- a/lib/Espfc/src/Sensor/GpsSensor.hpp
+++ b/lib/Espfc/src/Sensor/GpsSensor.hpp
@@ -64,6 +64,7 @@ private:
   void handleVersion() const;
   void checkSupport(const char* payload) const;
   void configureGnss();
+  void configureGnssValset();
 
   static constexpr uint32_t TIMEOUT = 300000;
   static constexpr uint32_t DETECT_TIMEOUT = 2200000;

--- a/lib/Gps/src/GpsProtocol.hpp
+++ b/lib/Gps/src/GpsProtocol.hpp
@@ -281,15 +281,15 @@ struct UbxCfgValsetKV
   uint8_t  value;
 } __attribute__((packed));
 
-// CFG-VALSET payload: 6 constellation ENA keys + 2 dual-band signal keys (GPS_L5, BDS_B2A)
-class UbxCfgValsetSignal
+template<size_t Size>
+class UbxCfgValset
 {
 public:
   static constexpr MsgId ID = UBX_CFG_VALSET;
   uint8_t version;      // 0
-  uint8_t layers;       // 0x07 = RAM + BBR + Flash
+  uint8_t layers;       // 0x01 = RAM only
   uint8_t reserved[2];
-  UbxCfgValsetKV kv[8]; // GPS, SBAS, GAL, BDS, QZSS, GLO, GPS_L5, BDS_B2A
+  UbxCfgValsetKV kv[Size];
 } __attribute__((packed));
 
 class UbxCfgNav5

--- a/lib/Gps/src/GpsProtocol.hpp
+++ b/lib/Gps/src/GpsProtocol.hpp
@@ -43,7 +43,8 @@ enum MsgId: uint16_t
   UBX_CFG_RATE     = 0x08 << 8 | UBX_CFG,  // Navigation/measurement rate settings
   UBX_CFG_SBAS     = 0x16 << 8 | UBX_CFG,  // SBAS configuration
   UBX_CFG_NAV5     = 0x24 << 8 | UBX_CFG,  // Navigation engine settings
-  UBX_CFG_GNSS     = 0x3E << 8 | UBX_CFG,  // GNSS system configuration
+  UBX_CFG_GNSS     = 0x3E << 8 | UBX_CFG,  // GNSS system configuration (deprecated >PROTVER 23.01)
+  UBX_CFG_VALSET   = 0x8A << 8 | UBX_CFG,  // Configuration input (Generation 9+, replaces legacy CFG-* messages)
 
   UBX_NAV_HPOSECEF = 0x13 << 8 | UBX_NAV,  // High precision position solution in ECEF (28 Bytes)
   UBX_NAV_HPOSLLH  = 0x14 << 8 | UBX_NAV,  // High precision geodetic position solution (36 Bytes)
@@ -262,6 +263,33 @@ public:
   uint8_t numTrkChUse;
   uint8_t numConfigBlocks;
   UbxCfgGnssBlock blocks[7];
+} __attribute__((packed));
+
+// CFG-SIGNAL key IDs for UBX-CFG-VALSET (PROTVER > 23.01, u-blox Interface Description UBX-23001092)
+constexpr uint32_t CFG_SIGNAL_GPS_ENA  = 0x10310001; // GPS enable
+constexpr uint32_t CFG_SIGNAL_GPS_L5   = 0x10310004; // GPS L5 signal enable (M10 dual-band)
+constexpr uint32_t CFG_SIGNAL_SBAS_ENA = 0x10310020; // SBAS enable
+constexpr uint32_t CFG_SIGNAL_GAL_ENA  = 0x10310021; // Galileo enable
+constexpr uint32_t CFG_SIGNAL_BDS_ENA  = 0x10310022; // BeiDou enable
+constexpr uint32_t CFG_SIGNAL_QZSS_ENA = 0x10310024; // QZSS enable
+constexpr uint32_t CFG_SIGNAL_GLO_ENA  = 0x10310025; // GLONASS enable
+constexpr uint32_t CFG_SIGNAL_BDS_B2A  = 0x10310028; // BeiDou B2a signal enable (M10 dual-band)
+
+struct UbxCfgValsetKV
+{
+  uint32_t key;
+  uint8_t  value;
+} __attribute__((packed));
+
+// CFG-VALSET payload: 6 constellation ENA keys + 2 dual-band signal keys (GPS_L5, BDS_B2A)
+class UbxCfgValsetSignal
+{
+public:
+  static constexpr MsgId ID = UBX_CFG_VALSET;
+  uint8_t version;      // 0
+  uint8_t layers;       // 0x07 = RAM + BBR + Flash
+  uint8_t reserved[2];
+  UbxCfgValsetKV kv[8]; // GPS, SBAS, GAL, BDS, QZSS, GLO, GPS_L5, BDS_B2A
 } __attribute__((packed));
 
 class UbxCfgNav5


### PR DESCRIPTION
UBX-CFG-GNSS is deprecated on u-blox Gen 9+ firmware (PROTVER > 23.01) and NAKs on some M10 variants (e.g. HGLRC M100), halting init.

- Parse PROTVER major from MON-VER ext strings into protVerMajor
- Branch in configureGnss(): PROTVER > 23 uses CFG-VALSET, else legacy
- configureGnssValset() sends UBX-CFG-VALSET (0x06/0x8A) with CFG-SIGNAL-* keys for all 6 constellations + L5/B2A for dual-band
- Add UBX_CFG_VALSET msg ID, CFG_SIGNAL_* constants, and UbxCfgValsetSignal struct to GpsProtocol.hpp

As discussed earlier in #200 here is proper fix, patch to skip error has been reverted back to old state (for stricter behavior on legacy hardware like M8/M9)
@rtlopez 