### PR TITLE
fix: enforce max arming angle and default to 25 deg

### DIFF
--- a/lib/Espfc/src/Connect/Cli.cpp
+++ b/lib/Espfc/src/Connect/Cli.cpp
@@ -576,6 +576,7 @@ const Cli::Param * Cli::initialize(ModelConfig& c)
     Param(PSTR("pid_level_rate_limit"), &c.level.rateLimit),
     Param(PSTR("pid_level_lpf_type"), &c.level.ptermFilter.type, filterTypeChoices),
     Param(PSTR("pid_level_lpf_freq"), &c.level.ptermFilter.freq),
+    Param(PSTR("small_angle"), &c.level.armingMaxAngle),
 
     Param(PSTR("pid_althold_vel_p"), &c.pid[FC_PID_VEL].P),
     Param(PSTR("pid_althold_vel_i"), &c.pid[FC_PID_VEL].I),

--- a/lib/Espfc/src/Connect/MspProcessor.cpp
+++ b/lib/Espfc/src/Connect/MspProcessor.cpp
@@ -770,7 +770,13 @@ void MspProcessor::processCommand(MspMessage& m, MspResponse& r, Device::SerialD
     case MSP_ARMING_CONFIG:
       r.writeU8(5); // auto_disarm delay
       r.writeU8(0);  // disarm kill switch
-      r.writeU8(180); // small angle
+      r.writeU8(_model.config.level.armingMaxAngle); // small angle
+      break;
+
+    case MSP_SET_ARMING_CONFIG:
+      m.readU8(); // auto_disarm delay (unused)
+      m.readU8(); // disarm kill switch (unused)
+      if(m.remain()) _model.config.level.armingMaxAngle = m.readU8();
       break;
 
     case MSP_RC_DEADBAND:

--- a/lib/Espfc/src/Control/Actuator.cpp
+++ b/lib/Espfc/src/Control/Actuator.cpp
@@ -96,6 +96,12 @@ void Actuator::updateArmingDisabled()
   _model.setArmingDisabled(ARMING_DISABLED_CALIBRATING,     _model.calibrationActive());
   _model.setArmingDisabled(ARMING_DISABLED_MOTOR_PROTOCOL,  _model.config.output.protocol == ESC_PROTOCOL_DISABLED);
   _model.setArmingDisabled(ARMING_DISABLED_REBOOT_REQUIRED, _model.state.mode.rescueConfigMode == RESCUE_CONFIG_ACTIVE);
+  if(_model.accelActive())
+  {
+    const float maxAngle = Utils::toRad(_model.config.level.armingMaxAngle);
+    const float angle = std::max(abs(_model.state.attitude.euler[AXIS_PITCH]), abs(_model.state.attitude.euler[AXIS_ROLL]));
+    _model.setArmingDisabled(ARMING_DISABLED_ANGLE, angle > maxAngle);
+  }
   if(_model.isFeatureActive(FEATURE_GPS))
   {
     _model.setArmingDisabled(ARMING_DISABLED_GPS, !_model.state.gps.present || _model.state.gps.numSats < _model.config.gps.minSats);

--- a/lib/Espfc/src/ModelConfig.h
+++ b/lib/Espfc/src/ModelConfig.h
@@ -638,6 +638,7 @@ struct LevelConfig
   FilterConfig ptermFilter{FILTER_PT1, 90};
   int8_t angleLimit = 55;
   int16_t rateLimit = 300;
+  uint8_t armingMaxAngle = 25; // max attitude (deg) allowed while arming; matches Betaflight small_angle default
 };
 
 struct AltHoldConfig


### PR DESCRIPTION
Refs #197 (addresses the arming-angle half of the issue).

## What was broken

The "Maximum arming angle" feature was effectively non-functional:

- `MSP_ARMING_CONFIG` returned a hardcoded `180` for `small_angle`, so the configurator UI displayed 180 regardless of any user setting.
- No `MSP_SET_ARMING_CONFIG` handler existed, so any value the user set in the configurator was silently dropped.
- `ARMING_DISABLED_ANGLE` is defined in `ModelConfig.h` but was never `setArmingDisabled(...)` anywhere — no attitude check was performed before arming.

Net effect: the drone would arm in any orientation, including upside-down, which is what the reporter observed.

## Fix

- Add `LevelConfig::armingMaxAngle` (default **25 deg**, matching Betaflight's `small_angle` default).
- In `Actuator::updateArmingDisabled()`, when the accelerometer is active, set `ARMING_DISABLED_ANGLE` if `max(|pitch|, |roll|) > armingMaxAngle`. The check is gated on `accelActive()` because attitude requires accel fusion to be meaningful (matches how `MODE_ANGLE` is already gated elsewhere).
- Report the configured value via `MSP_ARMING_CONFIG` and accept user changes via a new `MSP_SET_ARMING_CONFIG` handler.
- Expose as `small_angle` CLI parameter so it can also be set from the CLI.

15 added / 1 removed across 4 files.

## Notes

- The accelerometer trim half of #197 looks like a separate flow (calibration / IMU offsets) and warrants its own focused investigation — happy to follow up in another PR if you'd prefer.
- Adding a field to `ModelConfig` changes `sizeof(ModelConfig)`, which `Storage::load` already handles by returning `STORAGE_ERR_BAD_SIZE` and falling back to defaults. So existing users will simply get the new 25 deg default on first boot after flashing.
- The configurator UI default may also want updating on the configurator side, but that's a separate repo.