### PR TITLE
Min/max cell voltage adjustable

### DIFF
--- a/lib/Espfc/src/Connect/Buzzer.cpp
+++ b/lib/Espfc/src/Connect/Buzzer.cpp
@@ -86,8 +86,8 @@ const uint8_t** Buzzer::schemes()
   static const uint8_t beeperDisarming[] = { 10, 10, 0 };
   static const uint8_t beeperArming[] = { 20, 0 };
   static const uint8_t beeperSystemInit[] = { 10, 0 };
-  static const uint8_t beeperBatteryLow[] = { 10, 150, 0 };
-  static const uint8_t beeperBatteryCritical[] = { 10, 40, 0 };
+  static const uint8_t beeperBatteryLow[] = { 75, 0 };
+  static const uint8_t beeperBatteryCritical[] = { 30, 0 };
 
   static const uint8_t* beeperSchemes[] = {
     //BUZZER_SILENCE

--- a/lib/Espfc/src/Connect/Buzzer.cpp
+++ b/lib/Espfc/src/Connect/Buzzer.cpp
@@ -86,8 +86,8 @@ const uint8_t** Buzzer::schemes()
   static const uint8_t beeperDisarming[] = { 10, 10, 0 };
   static const uint8_t beeperArming[] = { 20, 0 };
   static const uint8_t beeperSystemInit[] = { 10, 0 };
-  static const uint8_t beeperBatteryLow[] = { 30, 0 };
-  static const uint8_t beeperBatteryCritical[] = { 50, 0 };
+  static const uint8_t beeperBatteryLow[] = { 10, 150, 0 };
+  static const uint8_t beeperBatteryCritical[] = { 10, 40, 0 };
 
   static const uint8_t* beeperSchemes[] = {
     //BUZZER_SILENCE

--- a/lib/Espfc/src/Connect/Cli.cpp
+++ b/lib/Espfc/src/Connect/Cli.cpp
@@ -441,6 +441,8 @@ const Cli::Param * Cli::initialize(ModelConfig& c)
     Param(PSTR("vbat_scale"), &c.vbat.scale),
     Param(PSTR("vbat_mul"), &c.vbat.resMult),
     Param(PSTR("vbat_div"), &c.vbat.resDiv),
+    Param(PSTR("vbat_cell_max"), &c.vbat.cellMax),
+    Param(PSTR("vbat_cell_min"), &c.vbat.cellMin),
     Param(PSTR("vbat_cell_warn"), &c.vbat.cellWarning),
 
     Param(PSTR("ibat_source"), &c.ibat.source, currentSourceChoices),
@@ -687,6 +689,7 @@ const Cli::Param * Cli::initialize(ModelConfig& c)
     Param(PSTR("pin_buzzer_invert"), &c.buzzer.inverted),
     Param(PSTR("pin_led_invert"), &c.led.invert),
     Param(PSTR("pin_led_type"), &c.led.type, ledTypeChoices),
+    Param(PSTR("beeper_mask"), &c.buzzer.beeperMask),
 
 #ifdef ESPFC_I2C_0
     Param(PSTR("i2c_speed"), &c.i2cSpeed),

--- a/lib/Espfc/src/Connect/MspProcessor.cpp
+++ b/lib/Espfc/src/Connect/MspProcessor.cpp
@@ -349,28 +349,28 @@ void MspProcessor::processCommand(MspMessage& m, MspResponse& r, Device::SerialD
       break;
 
     case MSP_BATTERY_CONFIG:
-      r.writeU8(34);  // vbatmincellvoltage
-      r.writeU8(42);  // vbatmaxcellvoltage
+      r.writeU8(_model.config.vbat.cellMin);  // vbatmincellvoltage
+      r.writeU8(_model.config.vbat.cellMax / 10);  // vbatmaxcellvoltage
       r.writeU8((_model.config.vbat.cellWarning + 5) / 10);  // vbatwarningcellvoltage
       r.writeU16(0); // batteryCapacity
       r.writeU8(_model.config.vbat.source);  // voltageMeterSource
       r.writeU8(_model.config.ibat.source);  // currentMeterSource
-      r.writeU16(340); // vbatmincellvoltage
-      r.writeU16(420); // vbatmaxcellvoltage
+      r.writeU16(_model.config.vbat.cellMin); // vbatmincellvoltage
+      r.writeU16(_model.config.vbat.cellMax); // vbatmaxcellvoltage
       r.writeU16(_model.config.vbat.cellWarning); // vbatwarningcellvoltage
       break;
 
     case MSP_SET_BATTERY_CONFIG:
-      m.readU8();  // vbatmincellvoltage
-      m.readU8();  // vbatmaxcellvoltage
+      _model.config.vbat.cellMin = m.readU8() * 10;  // vbatmincellvoltage
+      _model.config.vbat.cellMax = m.readU8() * 10;  // vbatmaxcellvoltage
       _model.config.vbat.cellWarning = m.readU8() * 10;  // vbatwarningcellvoltage
       m.readU16(); // batteryCapacity
       _model.config.vbat.source = toVbatSource(m.readU8());  // voltageMeterSource
       _model.config.ibat.source = toIbatSource(m.readU8());  // currentMeterSource
       if(m.remain() >= 6)
       {
-        m.readU16(); // vbatmincellvoltage
-        m.readU16(); // vbatmaxcellvoltage
+        _model.config.vbat.cellMin = m.readU16(); // vbatmincellvoltage
+        _model.config.vbat.cellMax = m.readU16(); // vbatmaxcellvoltage
         _model.config.vbat.cellWarning = m.readU16();
       }
       break;

--- a/lib/Espfc/src/Control/Actuator.cpp
+++ b/lib/Espfc/src/Control/Actuator.cpp
@@ -201,7 +201,11 @@ void Actuator::updateBuzzer()
   {
     _model.state.buzzer.play(BUZZER_RX_LOST);
   }
-  if(_model.state.battery.warn(_model.config.vbat.cellWarning))
+  if(_model.state.battery.warn(_model.config.vbat.cellMin))
+  {
+    _model.state.buzzer.play(BUZZER_BAT_CRIT_LOW);
+  }
+  else if(_model.state.battery.warn(_model.config.vbat.cellWarning))
   {
     _model.state.buzzer.play(BUZZER_BAT_LOW);
   }

--- a/lib/Espfc/src/Model.h
+++ b/lib/Espfc/src/Model.h
@@ -418,6 +418,7 @@ class Model
         1 << (BUZZER_RX_SET - 1) |
         1 << (BUZZER_DISARMING - 1) |
         1 << (BUZZER_ARMING - 1) |
+        1 << (BUZZER_BAT_CRIT_LOW - 1) |
         1 << (BUZZER_BAT_LOW - 1);
 
         if(config.gyro.dynamicFilter.count > DYN_NOTCH_COUNT_MAX)

--- a/lib/Espfc/src/ModelConfig.h
+++ b/lib/Espfc/src/ModelConfig.h
@@ -555,6 +555,8 @@ struct RpmFilterConfig
 
 struct VBatConfig
 {
+  int16_t cellMax = 420;      
+  int16_t cellMin = 330;
   int16_t cellWarning = 350;
   uint8_t scale = 100;
   uint8_t resDiv = 10;

--- a/lib/Espfc/src/Sensor/VoltageSensor.cpp
+++ b/lib/Espfc/src/Sensor/VoltageSensor.cpp
@@ -46,7 +46,7 @@ int VoltageSensor::update()
 int VoltageSensor::readVbat()
 {
 #ifdef ESPFC_ADC_0
-  if (_model.config.vbat.source != 1 || _model.config.pin[PIN_INPUT_ADC_0] == -1) return 0;
+  if (_model.config.vbat.source != 1 || _model.config.pin[PIN_INPUT_ADC_0] < 0) return 0;
   // wemos d1 mini has divider 3.2:1 (220k:100k)
   // additionaly I've used divider 5.7:1 (4k7:1k)
   // total should equals ~18.24:1, 73:4 resDiv:resMult should be ideal,
@@ -61,15 +61,19 @@ int VoltageSensor::readVbat()
   _model.state.battery.voltageUnfiltered = volts;
   _model.state.battery.voltage = _vFilter.update(_model.state.battery.voltageUnfiltered);
 
+  // Calculate the float value from decivolts
+  float maxCellV = _model.config.vbat.cellMax * 0.1f;
+  float minCellV = _model.config.vbat.cellMin * 0.1f;
+
   // cell count detection
   if (_model.state.battery.samples > 0)
   {
-    _model.state.battery.cells = std::ceil(_model.state.battery.voltage / 4.2f);
+    _model.state.battery.cells = std::ceil(_model.state.battery.voltage / maxCellV);
     _model.state.battery.samples--;
   }
 
   _model.state.battery.cellVoltage = _model.state.battery.voltage / constrain(_model.state.battery.cells, 1, 6);
-  _model.state.battery.percentage = Utils::clamp(Utils::map(_model.state.battery.cellVoltage, 3.4f, 4.2f, 0.0f, 100.0f), 0.0f, 100.0f);
+  _model.state.battery.percentage = Utils::clamp(Utils::map(_model.state.battery.cellVoltage, minCellV, maxCellV, 0.0f, 100.0f), 0.0f, 100.0f);
 
   if (_model.config.debug.mode == DEBUG_BATTERY)
   {
@@ -85,7 +89,7 @@ int VoltageSensor::readVbat()
 int VoltageSensor::readIbat()
 {
 #ifdef ESPFC_ADC_1
-  if (_model.config.ibat.source != 1 && _model.config.pin[PIN_INPUT_ADC_1] == -1) return 0;
+  if (_model.config.ibat.source != 1 && _model.config.pin[PIN_INPUT_ADC_1] < 0) return 0;
 
   _model.state.battery.rawCurrent = analogRead(_model.config.pin[PIN_INPUT_ADC_1]);
   float volts = _iFilterFast.update(_model.state.battery.rawCurrent * ESPFC_ADC_SCALE);


### PR DESCRIPTION
Problem: With max cell voltage hard coded to 4.2f, a fully charged 1 cells lip may be slightly above 4.2. This causes the readVbat function to calculate the lipo as 2 cells and then the measured voltage is well below min cell voltage. This cause the bat_low beeper to warn continuously if enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battery cell voltage calibration now user-configurable via CLI parameters
  * Added battery critical-low warning state

* **Bug Fixes**
  * Updated battery warning tone patterns
  * Improved battery voltage sensing with configurable min/max thresholds instead of hardcoded values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->