### PR TITLE
`ICM42688` IMU support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The mini, DIY, Low cost, ESP32 based, high performance flight controller for hob
 * ESC protocols (PWM, Oneshot125/42, Multishot, Brushed, Dshot150/300/600 bidirectional)
 * PPM, SBUS, IBUS and CRSF Receivers
 * Builtin ESP-NOW receiver and WiFi configuration [read more...](/docs/wireless.md)
-* SPI and I2C gyro modules support (MPU6050, MPU9250, ICM20602, BMI160)
+* SPI and I2C gyro modules support (MPU6050, MPU9250, ICM20602, ICM42688, BMI160)
 * Flight modes (ACRO, ANGLE, AIRMODE)
 * Frames (Quad X)
 * Betaflight configuration tool compatible (v10.10)
@@ -88,7 +88,7 @@ After flashing you need to configure few things first:
 
 ## Supported Sensors and Protocols
 
- * Gyro: MPU6050, MPU6000, MPU6500, MPU9250, ICM20602, BMI160
+ * Gyro: MPU6050, MPU6000, MPU6500, MPU9250, ICM20602, ICM42688, BMI160
  * Barometers: BMP180, BMP280, SPL06
  * Magnetometers: HMC5883, QMC5883, AK8963, QMC5883P
  * Receivers: PPM, SBUS, IBUS, CRSF/ELRS

--- a/lib/Espfc/src/Device/GyroDevice.cpp
+++ b/lib/Espfc/src/Device/GyroDevice.cpp
@@ -6,7 +6,7 @@ namespace Espfc::Device {
 
 const char ** GyroDevice::getNames()
 {
-  static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("MPU6000"), PSTR("MPU6050"), PSTR("MPU6500"), PSTR("MPU9250"), PSTR("LSM6DSO"), PSTR("ICM20602"),PSTR("BMI160"), NULL };
+  static const char* devChoices[] = { PSTR("AUTO"), PSTR("NONE"), PSTR("MPU6000"), PSTR("MPU6050"), PSTR("MPU6500"), PSTR("MPU9250"), PSTR("LSM6DSO"), PSTR("ICM20602"),PSTR("BMI160"), PSTR("ICM42688"), NULL};
   return devChoices;
 }
 

--- a/lib/Espfc/src/Device/GyroDevice.h
+++ b/lib/Espfc/src/Device/GyroDevice.h
@@ -16,6 +16,7 @@ enum GyroDeviceType {
   GYRO_LSM6DSO = 6,
   GYRO_ICM20602 = 7,
   GYRO_BMI160 = 8,
+  GYRO_ICM42688 = 9,
   GYRO_MAX
 };
 

--- a/lib/Espfc/src/Device/GyroICM42688.h
+++ b/lib/Espfc/src/Device/GyroICM42688.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include "Debug_Espfc.h"
+#include "GyroDevice.h"
+#include "Utils/MemoryHelper.h"
+#include "helper_3dmath.h"
+
+#define ICM42688_REG_WHO_AM_I         0x75
+#define ICM42688_REG_DEVICE_CONFIG    0x11
+#define ICM42688_REG_PWR_MGMT0        0x4E
+#define ICM42688_REG_GYRO_CONFIG0     0x4F
+#define ICM42688_REG_ACCEL_CONFIG0    0x50
+#define ICM42688_REG_ACCEL_DATA_X1    0x1F
+#define ICM42688_REG_GYRO_DATA_X1     0x25
+
+#define ICM42688_WHO_AM_I_VALUE       0x47
+#define ICM42688_SOFT_RESET           0x01
+#define ICM42688_PWR_GYRO_ACCEL_LN    0x0F
+#define ICM42688_GYRO_2000DPS_8KHZ    0x03
+#define ICM42688_ACCEL_16G_8KHZ       0x03
+
+namespace Espfc::Device {
+
+class GyroICM42688 : public GyroDevice
+{
+public:
+  int begin(BusDevice* bus) override
+  {
+    return begin(bus, 0);
+  }
+
+  int begin(BusDevice* bus, uint8_t addr) override
+  {
+    setBus(bus, addr);
+
+    if (!testConnection()) return 0;
+
+    _bus->writeByte(_addr, ICM42688_REG_DEVICE_CONFIG, ICM42688_SOFT_RESET);
+    delay(2); // datasheet: min 1ms after soft reset before register access
+
+    _bus->writeByte(_addr, ICM42688_REG_PWR_MGMT0, ICM42688_PWR_GYRO_ACCEL_LN);
+    delay(1);
+
+    _bus->writeByte(_addr, ICM42688_REG_GYRO_CONFIG0, ICM42688_GYRO_2000DPS_8KHZ);
+    _bus->writeByte(_addr, ICM42688_REG_ACCEL_CONFIG0, ICM42688_ACCEL_16G_8KHZ);
+
+    return 1;
+  }
+
+  GyroDeviceType getType() const override
+  {
+    return GYRO_ICM42688;
+  }
+
+  int FAST_CODE_ATTR readGyro(VectorInt16& v) override
+  {
+    uint8_t buffer[6];
+    _bus->readFast(_addr, ICM42688_REG_GYRO_DATA_X1, 6, buffer);
+    v.x = (((int16_t)buffer[0]) << 8) | buffer[1];
+    v.y = (((int16_t)buffer[2]) << 8) | buffer[3];
+    v.z = (((int16_t)buffer[4]) << 8) | buffer[5];
+    return 1;
+  }
+
+  int FAST_CODE_ATTR readAccel(VectorInt16& v) override
+  {
+    uint8_t buffer[6];
+    _bus->readFast(_addr, ICM42688_REG_ACCEL_DATA_X1, 6, buffer);
+    v.x = (((int16_t)buffer[0]) << 8) | buffer[1];
+    v.y = (((int16_t)buffer[2]) << 8) | buffer[3];
+    v.z = (((int16_t)buffer[4]) << 8) | buffer[5];
+    return 1;
+  }
+
+  // ICM-42688-P AAF lives in Bank 1 registers; no-op matches GyroBMI160 pattern
+  void setDLPFMode(uint8_t mode) override {}
+
+  int getRate() const override
+  {
+    return 8000;
+  }
+
+  void setRate(int rate) override {}
+
+  bool testConnection() override
+  {
+    uint8_t whoami = 0;
+    _bus->readByte(_addr, ICM42688_REG_WHO_AM_I, &whoami);
+    // D("icm42688:whoami", _addr, whoami);
+    return whoami == ICM42688_WHO_AM_I_VALUE;
+  }
+};
+
+}

--- a/lib/Espfc/src/Device/GyroICM42688.h
+++ b/lib/Espfc/src/Device/GyroICM42688.h
@@ -36,13 +36,13 @@ public:
     if (!testConnection()) return 0;
 
     _bus->writeByte(_addr, ICM42688_REG_DEVICE_CONFIG, ICM42688_SOFT_RESET);
-    delay(2); // datasheet: min 1ms after soft reset before register access
+    delay(2); // no check as min 1ms after soft reset is required before register access (see datasheet)
 
-    _bus->writeByte(_addr, ICM42688_REG_PWR_MGMT0, ICM42688_PWR_GYRO_ACCEL_LN);
+    if (!_bus->writeByte(_addr, ICM42688_REG_PWR_MGMT0, ICM42688_PWR_GYRO_ACCEL_LN)) return 0;
     delay(1);
 
-    _bus->writeByte(_addr, ICM42688_REG_GYRO_CONFIG0, ICM42688_GYRO_2000DPS_8KHZ);
-    _bus->writeByte(_addr, ICM42688_REG_ACCEL_CONFIG0, ICM42688_ACCEL_16G_8KHZ);
+    if (!_bus->writeByte(_addr, ICM42688_REG_GYRO_CONFIG0, ICM42688_GYRO_2000DPS_8KHZ)) return 0;
+    if (!_bus->writeByte(_addr, ICM42688_REG_ACCEL_CONFIG0, ICM42688_ACCEL_16G_8KHZ)) return 0;
 
     return 1;
   }

--- a/lib/Espfc/src/Hardware.cpp
+++ b/lib/Espfc/src/Hardware.cpp
@@ -5,6 +5,7 @@
 #include "Device/GyroBMI160.h"
 #include "Device/GyroDevice.h"
 #include "Device/GyroICM20602.h"
+#include "Device/GyroICM42688.h"
 #include "Device/GyroLSM6DSO.h"
 #include "Device/GyroMPU6050.h"
 #include "Device/GyroMPU6500.h"
@@ -39,6 +40,7 @@ static Espfc::Device::GyroMPU6500 mpu6500;
 static Espfc::Device::GyroMPU9250 mpu9250;
 static Espfc::Device::GyroLSM6DSO lsm6dso;
 static Espfc::Device::GyroICM20602 icm20602;
+static Espfc::Device::GyroICM42688 icm42688;
 static Espfc::Device::GyroBMI160 bmi160;
 static Espfc::Device::Mag::MagHMC5883L hmc5883l;
 static Espfc::Device::Mag::MagQMC5883L qmc5883l;
@@ -106,6 +108,7 @@ void Hardware::detectGyro()
     if (!detectedGyro && detectDevice(mpu9250, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu9250;
     if (!detectedGyro && detectDevice(mpu6500, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &mpu6500;
     if (!detectedGyro && detectDevice(icm20602, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &icm20602;
+    if (!detectedGyro && detectDevice(icm42688, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &icm42688;
     if (!detectedGyro && detectDevice(bmi160, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &bmi160;
     if (!detectedGyro && detectDevice(lsm6dso, spiBus, _model.config.pin[PIN_SPI_CS0])) detectedGyro = &lsm6dso;
     if (detectedGyro) gyroSlaveBus.begin(&spiBus, detectedGyro->getAddress());

--- a/platformio.ini
+++ b/platformio.ini
@@ -203,4 +203,5 @@ build_flags =
   -DNO_GLOBAL_INSTANCES
   -I ${PROJECT_DIR}/lib/Espfc/src
   -I ${PROJECT_DIR}/lib/EscDriver/src
+  -I ${PROJECT_DIR}/.pio/libdeps/native/ArduinoFake/src
 ;  -DUNITY_INCLUDE_PRINT_FORMATTED

--- a/platformio.ini
+++ b/platformio.ini
@@ -196,9 +196,11 @@ lib_deps =
   throwtheswitch/Unity@^2.6.0
 build_unflags =
   -std=gnu++11
-build_flags = 
+build_flags =
   -DIRAM_ATTR=""
   -DUNIT_TEST
   -std=c++17
   -DNO_GLOBAL_INSTANCES
+  -I ${PROJECT_DIR}/lib/Espfc/src
+  -I ${PROJECT_DIR}/lib/EscDriver/src
 ;  -DUNITY_INCLUDE_PRINT_FORMATTED

--- a/test/test_gyro/test_gyro_icm42688.cpp
+++ b/test/test_gyro/test_gyro_icm42688.cpp
@@ -6,13 +6,10 @@
 using namespace Espfc;
 using namespace Espfc::Device;
 
-// Minimal BusDevice mock for unit testing the ICM-42688-P driver.
-// Implements only the three pure-virtual methods; readByte/writeByte are
-// inherited non-virtual helpers that delegate to read()/write().
 class MockBusDevice : public BusDevice
 {
 public:
-  uint8_t readRegs[256] = {};   // registers returned by read/readFast
+  uint8_t readRegs[256] = {};   // registers ret
   uint8_t writeRegs[256] = {};  // registers captured by write
   int writeCalls = 0;
 
@@ -37,7 +34,6 @@ public:
   }
 };
 
-// U001: testConnection() returns true when WHO_AM_I == 0x47
 void test_whoami_match()
 {
   MockBusDevice bus;
@@ -47,7 +43,6 @@ void test_whoami_match()
   TEST_ASSERT_TRUE(dev.testConnection());
 }
 
-// U002: testConnection() returns false when WHO_AM_I != 0x47
 void test_whoami_mismatch()
 {
   MockBusDevice bus;
@@ -57,7 +52,6 @@ void test_whoami_mismatch()
   TEST_ASSERT_FALSE(dev.testConnection());
 }
 
-// U003: begin() returns 0 and issues no register writes when testConnection() fails
 void test_begin_aborts_on_failed_connection()
 {
   MockBusDevice bus;
@@ -68,11 +62,10 @@ void test_begin_aborts_on_failed_connection()
   TEST_ASSERT_EQUAL_INT(0, bus.writeCalls);
 }
 
-// U004: readGyro() decodes big-endian 6-byte buffer correctly
 void test_read_gyro_decoding()
 {
   MockBusDevice bus;
-  // gyro data registers start at 0x25; set big-endian pairs
+  // gyro data registers start at 0x25
   bus.readRegs[0x25] = 0x01; bus.readRegs[0x26] = 0x00; // X = 256
   bus.readRegs[0x27] = 0x02; bus.readRegs[0x28] = 0x00; // Y = 512
   bus.readRegs[0x29] = 0x03; bus.readRegs[0x2A] = 0x00; // Z = 768
@@ -85,7 +78,6 @@ void test_read_gyro_decoding()
   TEST_ASSERT_EQUAL_INT16(768, v.z);
 }
 
-// U005: readAccel() decodes big-endian 6-byte buffer correctly (incl. negative values)
 void test_read_accel_decoding()
 {
   MockBusDevice bus;
@@ -102,21 +94,18 @@ void test_read_accel_decoding()
   TEST_ASSERT_EQUAL_INT16(32767, v.z);
 }
 
-// U006: getType() returns GYRO_ICM42688
 void test_get_type()
 {
   GyroICM42688 dev;
   TEST_ASSERT_EQUAL_INT(GYRO_ICM42688, dev.getType());
 }
 
-// U007: getRate() returns 8000
 void test_get_rate()
 {
   GyroICM42688 dev;
   TEST_ASSERT_EQUAL_INT(8000, dev.getRate());
 }
 
-// U008: enum value and GYRO_MAX are correct at compile time
 void test_enum_values()
 {
   static_assert(GYRO_ICM42688 == 9, "GYRO_ICM42688 must equal 9 (append-only rule)");
@@ -124,7 +113,6 @@ void test_enum_values()
   TEST_PASS();
 }
 
-// U009: getName() returns "ICM42688" for GYRO_ICM42688
 void test_name_table()
 {
   const char* name = GyroDevice::getName(GYRO_ICM42688);

--- a/test/test_gyro/test_gyro_icm42688.cpp
+++ b/test/test_gyro/test_gyro_icm42688.cpp
@@ -1,0 +1,147 @@
+#include <unity.h>
+#include <ArduinoFake.h>
+#include "Device/GyroICM42688.h"
+#include "Device/GyroDevice.h"
+
+using namespace Espfc;
+using namespace Espfc::Device;
+
+// Minimal BusDevice mock for unit testing the ICM-42688-P driver.
+// Implements only the three pure-virtual methods; readByte/writeByte are
+// inherited non-virtual helpers that delegate to read()/write().
+class MockBusDevice : public BusDevice
+{
+public:
+  uint8_t readRegs[256] = {};   // registers returned by read/readFast
+  uint8_t writeRegs[256] = {};  // registers captured by write
+  int writeCalls = 0;
+
+  BusType getType() const override { return BUS_SPI; }
+
+  int8_t read(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t* data) override
+  {
+    for (uint8_t i = 0; i < length; i++) data[i] = readRegs[(regAddr + i) & 0xFF];
+    return length;
+  }
+
+  int8_t readFast(uint8_t devAddr, uint8_t regAddr, uint8_t length, uint8_t* data) override
+  {
+    return read(devAddr, regAddr, length, data);
+  }
+
+  bool write(uint8_t devAddr, uint8_t regAddr, uint8_t length, const uint8_t* data) override
+  {
+    for (uint8_t i = 0; i < length; i++) writeRegs[(regAddr + i) & 0xFF] = data[i];
+    writeCalls++;
+    return true;
+  }
+};
+
+// U001: testConnection() returns true when WHO_AM_I == 0x47
+void test_whoami_match()
+{
+  MockBusDevice bus;
+  bus.readRegs[0x75] = 0x47;
+  GyroICM42688 dev;
+  dev.setBus(&bus, 0);
+  TEST_ASSERT_TRUE(dev.testConnection());
+}
+
+// U002: testConnection() returns false when WHO_AM_I != 0x47
+void test_whoami_mismatch()
+{
+  MockBusDevice bus;
+  bus.readRegs[0x75] = 0x12; // ICM-20602 WHO_AM_I
+  GyroICM42688 dev;
+  dev.setBus(&bus, 0);
+  TEST_ASSERT_FALSE(dev.testConnection());
+}
+
+// U003: begin() returns 0 and issues no register writes when testConnection() fails
+void test_begin_aborts_on_failed_connection()
+{
+  MockBusDevice bus;
+  bus.readRegs[0x75] = 0x00;
+  GyroICM42688 dev;
+  int result = dev.begin(&bus, 0);
+  TEST_ASSERT_EQUAL_INT(0, result);
+  TEST_ASSERT_EQUAL_INT(0, bus.writeCalls);
+}
+
+// U004: readGyro() decodes big-endian 6-byte buffer correctly
+void test_read_gyro_decoding()
+{
+  MockBusDevice bus;
+  // gyro data registers start at 0x25; set big-endian pairs
+  bus.readRegs[0x25] = 0x01; bus.readRegs[0x26] = 0x00; // X = 256
+  bus.readRegs[0x27] = 0x02; bus.readRegs[0x28] = 0x00; // Y = 512
+  bus.readRegs[0x29] = 0x03; bus.readRegs[0x2A] = 0x00; // Z = 768
+  GyroICM42688 dev;
+  dev.setBus(&bus, 0);
+  VectorInt16 v;
+  dev.readGyro(v);
+  TEST_ASSERT_EQUAL_INT16(256, v.x);
+  TEST_ASSERT_EQUAL_INT16(512, v.y);
+  TEST_ASSERT_EQUAL_INT16(768, v.z);
+}
+
+// U005: readAccel() decodes big-endian 6-byte buffer correctly (incl. negative values)
+void test_read_accel_decoding()
+{
+  MockBusDevice bus;
+  // accel data registers start at 0x1F
+  bus.readRegs[0x1F] = 0xFF; bus.readRegs[0x20] = 0xFE; // X = -2
+  bus.readRegs[0x21] = 0x00; bus.readRegs[0x22] = 0x01; // Y = 1
+  bus.readRegs[0x23] = 0x7F; bus.readRegs[0x24] = 0xFF; // Z = 32767
+  GyroICM42688 dev;
+  dev.setBus(&bus, 0);
+  VectorInt16 v;
+  dev.readAccel(v);
+  TEST_ASSERT_EQUAL_INT16(-2,    v.x);
+  TEST_ASSERT_EQUAL_INT16(1,     v.y);
+  TEST_ASSERT_EQUAL_INT16(32767, v.z);
+}
+
+// U006: getType() returns GYRO_ICM42688
+void test_get_type()
+{
+  GyroICM42688 dev;
+  TEST_ASSERT_EQUAL_INT(GYRO_ICM42688, dev.getType());
+}
+
+// U007: getRate() returns 8000
+void test_get_rate()
+{
+  GyroICM42688 dev;
+  TEST_ASSERT_EQUAL_INT(8000, dev.getRate());
+}
+
+// U008: enum value and GYRO_MAX are correct at compile time
+void test_enum_values()
+{
+  static_assert(GYRO_ICM42688 == 9, "GYRO_ICM42688 must equal 9 (append-only rule)");
+  static_assert(GYRO_MAX == 10,     "GYRO_MAX must equal 10 after ICM42688 addition");
+  TEST_PASS();
+}
+
+// U009: getName() returns "ICM42688" for GYRO_ICM42688
+void test_name_table()
+{
+  const char* name = GyroDevice::getName(GYRO_ICM42688);
+  TEST_ASSERT_EQUAL_STRING("ICM42688", name);
+}
+
+int main(int argc, char** argv)
+{
+  UNITY_BEGIN();
+  RUN_TEST(test_whoami_match);
+  RUN_TEST(test_whoami_mismatch);
+  RUN_TEST(test_begin_aborts_on_failed_connection);
+  RUN_TEST(test_read_gyro_decoding);
+  RUN_TEST(test_read_accel_decoding);
+  RUN_TEST(test_get_type);
+  RUN_TEST(test_get_rate);
+  RUN_TEST(test_enum_values);
+  RUN_TEST(test_name_table);
+  return UNITY_END();
+}


### PR DESCRIPTION
Adds support for the InvenSense `ICM-42688` IMU via SPI. 
Tested on ESP32-S3 + ICM-42688-P over SPI.

This short video shows the CLI config and reacting betaflight 3D model afterwards:
https://www.youtube.com/watch?v=0jNeHUnhKN0

>Note on pin config in the demo video: the CLI commands shown (pin_spi_0_sck 1, pin_spi_0_mosi 2, pin_spi_0_miso 16, pin_spi_cs_0 4) differ from esp-fc S3 defaults because the test hardware uses a custom PCB with a non-standard SPI layout. The driver itself works with any pin assignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the **ICM42688** gyro/accelerometer, including gyro and accelerometer decoding.
  * Extended gyro detection and device selection so **ICM42688** is available when present.
* **Tests**
  * Added Unity tests for connection verification, initialization behavior, gyro/accel decoding, device type/name, and rate reporting.
* **Documentation**
  * Updated the README to list **ICM42688** as a supported gyro module.
* **Chores**
  * Updated native build include paths to expose required headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->