### PR TITLE
fix: disable f-term in angle mode

### DIFF
--- a/lib/Espfc/src/Control/Controller.cpp
+++ b/lib/Espfc/src/Control/Controller.cpp
@@ -150,8 +150,6 @@ void FAST_CODE_ATTR Controller::outerLoop()
     {
       const float angleSetpoint = Utils::toRad(_model.config.level.angleLimit) * _model.state.input.ch[i];
       _model.state.setpoint.rate[i] = _model.state.outerPid[i].update(angleSetpoint, _model.state.attitude.euler[i]);
-      // disable fterm in angle mode
-      _model.state.innerPid[i].fScale = 0.f;
     }
   }
   else
@@ -197,7 +195,14 @@ void FAST_CODE_ATTR Controller::innerLoop()
 
   for (size_t i = 0; i < AXIS_COUNT_RPY; ++i)
   {
-    output.ch[i] = innerPid[i].update(setpoint.rate[i], _model.state.gyro.adc[i]) * tpaFactor;
+    auto& pid = innerPid[i];
+    const float fScale = pid.fScale; // disable f-term in angle mode
+    if (_model.isModeActive(MODE_ANGLE) && i < AXIS_COUNT_RP)
+    {
+      pid.fScale = 0.f;
+    }
+    output.ch[i] = pid.update(setpoint.rate[i], _model.state.gyro.adc[i]) * tpaFactor;
+    pid.fScale = fScale;
   }
 
   // thrust control

--- a/test/test_fc/test_fc.cpp
+++ b/test/test_fc/test_fc.cpp
@@ -297,6 +297,38 @@ void test_controller_rates_limit()
   TEST_ASSERT_FLOAT_WITHIN(0.01f, -6.98f, controller.calculateSetpointRate(AXIS_YAW, 1.0f));
 }
 
+void test_controller_angle_mode_does_not_latch_fterm_scale()
+{
+  When(Method(ArduinoFake(), micros)).AlwaysReturn(0);
+
+  Model model;
+  model.state.gyro.clock = 1000;
+  model.config.gyro.dlpf = GYRO_DLPF_256;
+  model.config.loopSync = 1;
+  model.config.mixerSync = 1;
+  model.config.mixer.type = FC_MIXER_QUADX;
+  model.config.pid[FC_PID_ROLL] = {.P = 0u, .I = 0u, .D = 0u, .F = 100};
+  model.config.input.filterDerivative = {FILTER_NONE, 0};
+  model.begin();
+
+  Controller controller(model);
+  controller.begin();
+
+  model.state.input.ch[AXIS_ROLL] = 1.f;
+  model.updateModes(1 << MODE_ANGLE);
+  controller.update();
+
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, model.state.innerPid[AXIS_ROLL].fScale);
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 0.0f, model.state.innerPid[AXIS_ROLL].fTerm);
+
+  model.clearMode(MODE_ANGLE);
+  model.state.input.ch[AXIS_ROLL] = 0.f;
+  controller.update();
+
+  TEST_ASSERT_FLOAT_WITHIN(0.001f, 1.0f, model.state.innerPid[AXIS_ROLL].fScale);
+  TEST_ASSERT_TRUE(model.state.innerPid[AXIS_ROLL].fTerm < -0.001f || model.state.innerPid[AXIS_ROLL].fTerm > 0.001f);
+}
+
 void test_rates_betaflight()
 {
   InputConfig config;
@@ -645,6 +677,7 @@ int main(int argc, char** argv)
   RUN_TEST(test_model_outer_pid_init);
   RUN_TEST(test_controller_rates);
   RUN_TEST(test_controller_rates_limit);
+  RUN_TEST(test_controller_angle_mode_does_not_latch_fterm_scale);
   RUN_TEST(test_rates_betaflight);
   RUN_TEST(test_rates_betaflight_expo);
   RUN_TEST(test_rates_raceflight);


### PR DESCRIPTION
ensure f-term scale do not latch when disabing angle-mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed angle mode behavior so PID F-term scaling is restored correctly after leaving angle mode.
  * Prevented F-term scaling from remaining disabled for roll and pitch control.

* **Tests**
  * Added coverage to verify F-term output resumes correctly when angle mode is exited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->